### PR TITLE
feat(sentinel): Day 1 - Sentinel package foundation + MITRE ATT&CK ma…

### DIFF
--- a/backend/database/migrations/add_detected_signatures.sql
+++ b/backend/database/migrations/add_detected_signatures.sql
@@ -1,0 +1,13 @@
+-- Migration: Add detected_signatures to packet_logs
+-- Phase 5 — Sentinel Layer (Week 1, Day 1)
+-- Issue: #673 (sentinel_service.py will populate this on Day 5)
+--
+-- ⚠️  This column is STORAGE ONLY at this stage.
+--     Population logic lives exclusively in sentinel_service.py.
+--     Service type is inferred from dst_port:
+--       2222 → SSH | 8080 → HTTP | 2121 → FTP | 2525 → SMTP
+--
+-- Run automatically via SQLAlchemy Base.metadata.create_all() on startup
+-- (SQLite ADD COLUMN is idempotent-safe when run once).
+
+ALTER TABLE packet_logs ADD COLUMN detected_signatures VARCHAR;

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -40,6 +40,14 @@ class PacketLog(Base):
     latitude = Column(Float, nullable=True)
     longitude = Column(Float, nullable=True)
 
+    # Sentinel Layer — Signature Storage (Phase 5)
+    # Populated by sentinel_service.py (Issue #673, Day 5).
+    # Service type is inferred from dst_port:
+    #   2222 → SSH | 8080 → HTTP | 2121 → FTP | 2525 → SMTP
+    # Raw payloads are sourced from the events table.
+    # ⚠️  Do NOT populate this column anywhere else.
+    detected_signatures = Column(String, nullable=True)
+
 
 class Alert(Base):
     __tablename__ = "alerts"

--- a/backend/sentinel/__init__.py
+++ b/backend/sentinel/__init__.py
@@ -1,0 +1,26 @@
+"""
+backend/sentinel/__init__.py
+----------------------------
+PhantomNet Sentinel Layer — Package Root
+
+This package implements the Sentinel threat intelligence pipeline:
+
+  - mitre_mapper.py         : Maps attack types to MITRE ATT&CK techniques
+  - rule_generator.py       : Generates Snort / Sigma detection rules
+  - playbook_generator.py   : Renders Jinja2 response playbooks
+  - stix_enhanced.py        : Produces enriched STIX 2.1 bundles
+  - sentinel_service.py     : Orchestration service (Day 5 — Issue #673)
+                              Populates PacketLog.detected_signatures by
+                              inferring service type from dst_port and
+                              querying the events table for raw payloads.
+
+Sub-packages
+------------
+  templates/                : Jinja2 playbook templates (.j2 files)
+
+⚠️  Population of PacketLog.detected_signatures is handled exclusively
+    by sentinel_service.py — do NOT write signature logic elsewhere.
+"""
+
+# Package version — kept in sync with backend/main.py app version
+__version__ = "3.0.0-sentinel"

--- a/backend/sentinel/mitre_mapper.py
+++ b/backend/sentinel/mitre_mapper.py
@@ -1,0 +1,222 @@
+"""
+backend/sentinel/mitre_mapper.py
+---------------------------------
+PhantomNet Sentinel Layer — MITRE ATT&CK Technique Mapper
+
+Translates raw signature names (produced by ml/signatures.py SignatureEngine)
+into structured MITRE ATT&CK technique objects.
+
+Signature → ATT&CK mapping (Phase 5, Week 1, Day 2):
+  SSH_AUTH_FAILURE    → T1110.001  Brute Force: Password Guessing
+  SSH_HIGH_ACTIVITY   → T1021.004  Remote Services: SSH
+  HTTP_SQL_INJECTION  → T1190      Exploit Public-Facing Application
+  HTTP_XSS_ATTEMPT    → T1059.007  Command and Scripting: JavaScript
+  HTTP_PATH_TRAVERSAL → T1083      File and Directory Discovery
+  HTTP_SCANNER_BEHAVIOR→ T1046     Network Service Scanning
+
+Public API
+----------
+  map_signature(signature_name: str) -> dict | None
+      Maps a single signature name to an ATT&CK technique dict.
+      Returns None if the signature is not in the mapping table.
+
+  map_signatures(signature_names: list[str]) -> list[dict]
+      Maps a list of signature names, skipping any unmapped ones.
+      Returns deduplicated results by technique_id.
+
+  get_all_techniques() -> list[dict]
+      Returns the full mapping table as a list (for API/UI consumption).
+
+ATT&CK Technique Object Schema
+-------------------------------
+  {
+    "technique_id":   str   # e.g. "T1110.001"
+    "technique_name": str   # e.g. "Brute Force: Password Guessing"
+    "tactic":         str   # e.g. "Credential Access"
+    "tactic_id":      str   # e.g. "TA0006"
+    "description":    str   # Short human-readable description
+    "url":            str   # Official ATT&CK reference URL
+    "severity":       str   # "CRITICAL" | "HIGH" | "MEDIUM" | "LOW"
+    "signature":      str   # Source signature name that triggered this
+  }
+"""
+
+from __future__ import annotations
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# MITRE ATT&CK Technique Lookup Table
+# Key   : signature name (matches SignatureEngine output exactly)
+# Value : ATT&CK technique dict (signature field populated by map_signature())
+# ---------------------------------------------------------------------------
+_TECHNIQUE_MAP: dict[str, dict] = {
+    # ── SSH ─────────────────────────────────────────────────────────────────
+    "SSH_AUTH_FAILURE": {
+        "technique_id":   "T1110.001",
+        "technique_name": "Brute Force: Password Guessing",
+        "tactic":         "Credential Access",
+        "tactic_id":      "TA0006",
+        "description": (
+            "Adversaries attempt to gain access to accounts by systematically "
+            "guessing passwords. Repeated SSH authentication failures indicate "
+            "an automated or manual password-guessing campaign targeting the "
+            "honeypot service."
+        ),
+        "url": "https://attack.mitre.org/techniques/T1110/001/",
+        "severity": "HIGH",
+    },
+    "SSH_HIGH_ACTIVITY": {
+        "technique_id":   "T1021.004",
+        "technique_name": "Remote Services: SSH",
+        "tactic":         "Lateral Movement",
+        "tactic_id":      "TA0008",
+        "description": (
+            "Adversaries use Secure Shell (SSH) to log into remote machines "
+            "during lateral movement. Elevated SSH session activity above normal "
+            "thresholds suggests an attacker may be actively exploring or "
+            "pivoting through the network via the SSH honeypot."
+        ),
+        "url": "https://attack.mitre.org/techniques/T1021/004/",
+        "severity": "MEDIUM",
+    },
+
+    # ── HTTP ─────────────────────────────────────────────────────────────────
+    "HTTP_SQL_INJECTION": {
+        "technique_id":   "T1190",
+        "technique_name": "Exploit Public-Facing Application",
+        "tactic":         "Initial Access",
+        "tactic_id":      "TA0001",
+        "description": (
+            "Adversaries exploit vulnerabilities in internet-facing applications "
+            "to gain initial access. SQL injection payloads detected in HTTP "
+            "requests (UNION, SELECT, DROP) indicate an attempt to manipulate "
+            "the backend database and potentially extract sensitive data."
+        ),
+        "url": "https://attack.mitre.org/techniques/T1190/",
+        "severity": "CRITICAL",
+    },
+    "HTTP_XSS_ATTEMPT": {
+        "technique_id":   "T1059.007",
+        "technique_name": "Command and Scripting Interpreter: JavaScript",
+        "tactic":         "Execution",
+        "tactic_id":      "TA0002",
+        "description": (
+            "Adversaries abuse JavaScript to execute malicious commands in a "
+            "victim's browser context. Cross-site scripting (XSS) payloads "
+            "detected in HTTP requests (<script>, onerror=) indicate an attempt "
+            "to inject and execute client-side scripts against application users."
+        ),
+        "url": "https://attack.mitre.org/techniques/T1059/007/",
+        "severity": "HIGH",
+    },
+    "HTTP_PATH_TRAVERSAL": {
+        "technique_id":   "T1083",
+        "technique_name": "File and Directory Discovery",
+        "tactic":         "Discovery",
+        "tactic_id":      "TA0007",
+        "description": (
+            "Adversaries enumerate files and directories to understand the "
+            "system layout and locate sensitive data. Path traversal sequences "
+            "(../) detected in HTTP requests indicate an attempt to access "
+            "files outside the web root, such as /etc/passwd or configuration "
+            "files."
+        ),
+        "url": "https://attack.mitre.org/techniques/T1083/",
+        "severity": "HIGH",
+    },
+    "HTTP_SCANNER_BEHAVIOR": {
+        "technique_id":   "T1046",
+        "technique_name": "Network Service Scanning",
+        "tactic":         "Discovery",
+        "tactic_id":      "TA0007",
+        "description": (
+            "Adversaries scan networks to discover accessible services and "
+            "potential attack vectors. High URL request rates from a single "
+            "source indicate automated scanner or web crawler behaviour probing "
+            "the HTTP honeypot for vulnerable endpoints."
+        ),
+        "url": "https://attack.mitre.org/techniques/T1046/",
+        "severity": "MEDIUM",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def map_signature(signature_name: str) -> Optional[dict]:
+    """
+    Map a single signature name to its MITRE ATT&CK technique.
+
+    Args:
+        signature_name: Exact string as returned by SignatureEngine.check_signatures()
+                        e.g. "SSH_AUTH_FAILURE"
+
+    Returns:
+        A technique dict with a 'signature' field populated, or None if the
+        signature is not in the mapping table.
+
+    Example:
+        >>> result = map_signature("SSH_AUTH_FAILURE")
+        >>> result["technique_id"]
+        'T1110.001'
+    """
+    template = _TECHNIQUE_MAP.get(signature_name)
+    if template is None:
+        return None
+    # Return a copy so callers cannot mutate the master table
+    technique = dict(template)
+    technique["signature"] = signature_name
+    return technique
+
+
+def map_signatures(signature_names: list) -> list:
+    """
+    Map a list of signature names to ATT&CK techniques.
+
+    Unmapped signatures are silently skipped.
+    Deduplicates by technique_id so the same technique is not returned twice
+    even if multiple signatures resolve to it.
+
+    Args:
+        signature_names: List of signature strings from SignatureEngine.
+
+    Returns:
+        List of technique dicts, one per unique technique_id found.
+
+    Example:
+        >>> sigs = ["SSH_AUTH_FAILURE", "UNKNOWN_SIG", "HTTP_SQL_INJECTION"]
+        >>> results = map_signatures(sigs)
+        >>> len(results)  # UNKNOWN_SIG is skipped
+        2
+    """
+    seen_ids: set[str] = set()
+    techniques: list[dict] = []
+
+    for sig in signature_names:
+        technique = map_signature(sig)
+        if technique is None:
+            continue
+        tid = technique["technique_id"]
+        if tid not in seen_ids:
+            seen_ids.add(tid)
+            techniques.append(technique)
+
+    return techniques
+
+
+def get_all_techniques() -> list:
+    """
+    Return the complete ATT&CK technique mapping table.
+
+    Useful for API endpoints that expose the full technique catalogue
+    or for seeding the Sentinel Dashboard's technique reference panel.
+
+    Returns:
+        List of all technique dicts with 'signature' populated.
+    """
+    return [
+        {**template, "signature": sig}
+        for sig, template in _TECHNIQUE_MAP.items()
+    ]

--- a/backend/sentinel/rule_generator.py
+++ b/backend/sentinel/rule_generator.py
@@ -1,7 +1,36 @@
+"""
+backend/sentinel/rule_generator.py
+------------------------------------
+PhantomNet Sentinel Layer — Snort Rule Generator
+
+Generates Snort IDS rules from ATT&CK technique data captured by the
+Sentinel pipeline. Rules are produced by sentinel_service.py and can be
+exported from the Sentinel Dashboard.
+
+Public API
+----------
+  generate_snort_rule(src_ip, dst_port, protocol, attack_desc,
+                      technique_id, sid) -> str
+      Generates a single formatted Snort rule string.
+      Raises ValueError on invalid inputs.
+
+  validate_ip(ip_str) -> bool
+      Returns True for valid IPv4, CIDR, or Snort keywords (any, $HOME_NET).
+
+  validate_port(port) -> bool
+      Returns True for valid port number (0-65535) or 'any'.
+
+  SNORT_RULE_TEMPLATE : str
+      The raw template string used for rule generation.
+"""
+
 import ipaddress
 import typing
 
-# Template string with msg, flow, threshold, classtype, reference fields
+# ---------------------------------------------------------------------------
+# Snort Rule Template
+# Fields: protocol, src_ip, dst_port, attack_desc, technique_id, sid
+# ---------------------------------------------------------------------------
 SNORT_RULE_TEMPLATE = (
     'alert {protocol} {src_ip} any -> $HOME_NET {dst_port} ('
     'msg:"{attack_desc}"; '
@@ -13,6 +42,7 @@ SNORT_RULE_TEMPLATE = (
     'rev:1;'
     ')'
 )
+
 
 def validate_ip(ip_str: str) -> bool:
     """Validate if the string is a valid IP address or allowed variable/keyword."""
@@ -30,6 +60,7 @@ def validate_ip(ip_str: str) -> bool:
     except ValueError:
         return False
 
+
 def validate_port(port: typing.Union[int, str]) -> bool:
     """Validate if the port is a valid port number or 'any'."""
     if isinstance(port, str) and port.lower() == "any":
@@ -40,41 +71,49 @@ def validate_port(port: typing.Union[int, str]) -> bool:
     except ValueError:
         return False
 
-def generate_snort_rule(src_ip: str, dst_port: typing.Union[int, str], protocol: str, attack_desc: str, technique_id: str, sid: int) -> str:
+
+def generate_snort_rule(
+    src_ip: str,
+    dst_port: typing.Union[int, str],
+    protocol: str,
+    attack_desc: str,
+    technique_id: str,
+    sid: int,
+) -> str:
     """
     Generates a Snort rule string based on the provided parameters.
-    
+
     Args:
-        src_ip: Source IP address (e.g., '192.168.1.1', 'any', '$EXTERNAL_NET')
-        dst_port: Destination port (e.g., 22, 80, 'any')
-        protocol: Network protocol (e.g., 'tcp', 'udp', 'icmp')
-        attack_desc: Description of the attack for the 'msg' field
+        src_ip:       Source IP address (e.g., '192.168.1.1', 'any', '$EXTERNAL_NET')
+        dst_port:     Destination port (e.g., 22, 80, 'any')
+        protocol:     Network protocol (e.g., 'tcp', 'udp', 'icmp')
+        attack_desc:  Description of the attack for the 'msg' field
         technique_id: MITRE ATT&CK technique ID for the 'reference' field
-        sid: Snort rule ID
-        
+        sid:          Snort rule ID
+
     Returns:
         A formatted Snort rule string.
-        
+
     Raises:
         ValueError: If input parameters are invalid.
     """
     if not validate_ip(src_ip):
         raise ValueError(f"Invalid source IP address: {src_ip}")
-        
+
     if not validate_port(dst_port):
         raise ValueError(f"Invalid destination port: {dst_port}")
-        
+
     protocol = protocol.lower()
     if protocol not in ("tcp", "udp", "icmp", "ip"):
         raise ValueError(f"Unsupported protocol: {protocol}")
-        
+
     rule = SNORT_RULE_TEMPLATE.format(
         protocol=protocol,
         src_ip=src_ip,
         dst_port=dst_port,
         attack_desc=attack_desc,
         technique_id=technique_id,
-        sid=sid
+        sid=sid,
     )
-    
+
     return rule

--- a/backend/sentinel/templates/.gitkeep
+++ b/backend/sentinel/templates/.gitkeep
@@ -1,0 +1,15 @@
+# backend/sentinel/templates/
+#
+# Jinja2 playbook templates live here.
+# Each .j2 file represents one response playbook type:
+#
+#   ssh_brute_force.j2      — SSH brute-force attack playbook
+#   sql_injection.j2        — SQL injection attack playbook
+#   port_scan.j2            — Port scan / reconnaissance playbook
+#   generic_threat.j2       — Generic / fallback playbook
+#
+# Templates are rendered by backend/sentinel/playbook_generator.py
+# during Phase 5 Week 1 execution.
+#
+# Directory is intentionally left empty for now — templates are
+# added in Plan 5.1 (Week 1, Days 2-3).


### PR DESCRIPTION
…pper

Phase 5 Week 1 Day 1 deliverables (master_plan_month1.md):

Task S-1: Create backend/sentinel/ package
- backend/sentinel/__init__.py — package root with full docstring
- backend/sentinel/templates/ — Jinja2 playbook templates directory (Day 3+)
- database/models.py — add detected_signatures = Column(String, nullable=True) to PacketLog
- database/migrations/add_detected_signatures.sql — ALTER TABLE migration applied to phantomnet.db NOTE: Column is storage-only. Population deferred to sentinel_service.py (Day 5, Issue #673) WARN: Do NOT populate inside _apply_threat_result() — SignatureEngine expects different dict shape

Task S-2: sentinel/mitre_mapper.py — 6 ATT&CK mappings (Part 1)
- SSH_AUTH_FAILURE    -> T1110.001 (Brute Force: Password Guessing)    [Credential Access]
- SSH_HIGH_ACTIVITY   -> T1021.004 (Remote Services: SSH)              [Lateral Movement]
- HTTP_SQL_INJECTION  -> T1190     (Exploit Public-Facing Application) [Initial Access]
- HTTP_XSS_ATTEMPT    -> T1059.007 (Command and Scripting: JavaScript) [Execution]
- HTTP_PATH_TRAVERSAL -> T1083     (File and Directory Discovery)      [Discovery]
- HTTP_SCANNER_BEHAVIOR-> T1046    (Network Service Scanning)          [Discovery]

Task V-1: sentinel/rule_generator.py — Snort rule scaffold
- Moved from erroneous root-level sentinel/ to correct backend/sentinel/
- generate_snort_rule(src_ip, dst_port, protocol, attack_desc, technique_id, sid) -> str
- SNORT_RULE_TEMPLATE with msg, flow, threshold, classtype, reference fields
- validate_ip() and validate_port() helpers
- 7/7 pytest tests pass in tests/test_rule_generator.py

Project cleanup:
- Removed duplicate sentinel/ at project root
- Removed empty sriram21-09/ directory

All 8 deliverables verified against master plan. 0 errors.