### PR TITLE
feat(sentinel): PlaybookGenerator – Jinja2 env, generate(), validate_context(), list_templates() + 43 tests

### DIFF
--- a/sentinel/__init__.py
+++ b/sentinel/__init__.py
@@ -1,0 +1,3 @@
+from .playbook_generator import PlaybookGenerator
+
+__all__ = ["PlaybookGenerator"]

--- a/sentinel/playbook_generator.py
+++ b/sentinel/playbook_generator.py
@@ -1,0 +1,70 @@
+import os
+import logging
+from typing import Dict, Any
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound
+
+logger = logging.getLogger("sentinel.playbook_generator")
+
+class PlaybookGenerator:
+    """
+    Scaffold for dynamic incident response playbook generation.
+    Configures a Jinja2 environment with FileSystemLoader pointing to the templates directory
+    and renders playbooks based on provided context and attack patterns.
+    """
+    def __init__(self, templates_dir: str = None):
+        if templates_dir is None:
+            # Default to the 'templates' folder relative to this file
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            templates_dir = os.path.join(current_dir, "templates")
+        
+        logger.info(f"Initializing PlaybookGenerator with templates directory: {templates_dir}")
+        self.loader = FileSystemLoader(templates_dir)
+        self.env = Environment(loader=self.loader, autoescape=False)
+
+    def _select_template(self, attack_pattern: str) -> str:
+        """
+        Selects the appropriate Jinja2 template file based on the attack_pattern.
+        """
+        if not attack_pattern:
+            raise ValueError("attack_pattern must be provided to select a template.")
+            
+        pattern = attack_pattern.lower().strip()
+        
+        # Mappings matching standard attack patterns to templates
+        if "brute_force" in pattern or "brute-force" in pattern or "failed_login" in pattern:
+            return "brute_force_response.yaml.j2"
+        elif "port_scan" in pattern or "port-scan" in pattern or "scan" in pattern:
+            return "port_scan_response.yaml.j2"
+        elif "credential_reuse" in pattern or "credential-reuse" in pattern or "honeytoken" in pattern:
+            return "credential_reuse_response.yaml.j2"
+        elif "distributed_attack" in pattern or "distributed-attack" in pattern or "distributed" in pattern:
+            return "distributed_attack_response.yaml.j2"
+        else:
+            # Default fallback mapping
+            logger.warning(f"Unknown attack pattern: '{attack_pattern}'. Defaulting to pattern-based template name.")
+            return f"{pattern}_response.yaml.j2"
+
+    def generate(self, context_data: Dict[str, Any]) -> str:
+        """
+        Generates a playbook YAML string by selecting a template based on the 
+        'attack_pattern' parameter in context_data and rendering it.
+        """
+        attack_pattern = context_data.get("attack_pattern")
+        if not attack_pattern:
+            raise ValueError("context_data must contain an 'attack_pattern' key.")
+
+        template_name = self._select_template(attack_pattern)
+        logger.info(f"Selected template: {template_name} for attack pattern: {attack_pattern}")
+
+        try:
+            template = self.env.get_template(template_name)
+        except TemplateNotFound:
+            logger.error(f"Template not found: {template_name}")
+            raise FileNotFoundError(f"Template '{template_name}' not found for attack pattern '{attack_pattern}'")
+
+        try:
+            rendered_yaml = template.render(context_data)
+            return rendered_yaml
+        except Exception as e:
+            logger.error(f"Failed to render template {template_name}: {e}")
+            raise

--- a/sentinel/playbook_generator.py
+++ b/sentinel/playbook_generator.py
@@ -1,70 +1,302 @@
+"""
+sentinel/playbook_generator.py
+-------------------------------
+Dynamic incident-response playbook generation using Jinja2 templates.
+
+The :class:`PlaybookGenerator` class configures a Jinja2 ``Environment``
+backed by a ``FileSystemLoader`` that points at ``sentinel/templates/``.
+Calling :meth:`~PlaybookGenerator.generate` with a context dictionary
+selects the correct ``.yaml.j2`` template based on the ``attack_pattern``
+key and returns the fully-rendered YAML string ready for downstream
+automation systems (SOAR, SDN controllers, etc.).
+
+Supported attack patterns
+~~~~~~~~~~~~~~~~~~~~~~~~~
++------------------------+--------------------------------------+
+| Pattern keyword(s)     | Template selected                    |
++========================+======================================+
+| brute_force / brute-force / failed_login | brute_force_response.yaml.j2 |
++------------------------+--------------------------------------+
+| port_scan / port-scan / scan            | port_scan_response.yaml.j2   |
++------------------------+--------------------------------------+
+| credential_reuse / credential-reuse / honeytoken | credential_reuse_response.yaml.j2 |
++------------------------+--------------------------------------+
+| distributed_attack / distributed-attack / distributed | distributed_attack_response.yaml.j2 |
++------------------------+--------------------------------------+
+| *anything else*        | ``{pattern}_response.yaml.j2``       |
++------------------------+--------------------------------------+
+
+Usage example
+~~~~~~~~~~~~~
+::
+
+    from sentinel.playbook_generator import PlaybookGenerator
+
+    gen = PlaybookGenerator()
+    playbook_yaml = gen.generate({
+        "attack_pattern": "brute_force",
+        "source_ip": "192.168.1.100",
+        "failed_logins_threshold": 30,
+        "alert_level": "CRITICAL",
+    })
+    print(playbook_yaml)
+"""
+
 import os
 import logging
-from typing import Dict, Any
+from typing import Any, Dict, List, Optional
+
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 
+# ---------------------------------------------------------------------------
+# Module-level logger – inherits configuration from the root logger so that
+# the calling application controls verbosity via standard logging setup.
+# ---------------------------------------------------------------------------
 logger = logging.getLogger("sentinel.playbook_generator")
 
+
 class PlaybookGenerator:
+    """Dynamically generate incident-response playbooks from Jinja2 templates.
+
+    On instantiation a Jinja2 :class:`~jinja2.Environment` is configured
+    with a :class:`~jinja2.FileSystemLoader` pointing at the
+    ``sentinel/templates/`` directory (or a custom path supplied by the
+    caller).  The :meth:`generate` method selects the appropriate template
+    for a given ``attack_pattern`` and renders it with the provided context.
+
+    Parameters
+    ----------
+    templates_dir:
+        Absolute or relative path to the directory that contains the
+        ``*.yaml.j2`` template files.  When *None* (default) the loader
+        resolves ``templates/`` relative to this source file, i.e.
+        ``sentinel/templates/``.
+
+    Attributes
+    ----------
+    templates_dir : str
+        Resolved, absolute path to the templates directory.
+    loader : jinja2.FileSystemLoader
+        Jinja2 loader bound to :attr:`templates_dir`.
+    env : jinja2.Environment
+        Configured Jinja2 environment (auto-escape disabled; safe for YAML).
     """
-    Scaffold for dynamic incident response playbook generation.
-    Configures a Jinja2 environment with FileSystemLoader pointing to the templates directory
-    and renders playbooks based on provided context and attack patterns.
-    """
-    def __init__(self, templates_dir: str = None):
+
+    # ------------------------------------------------------------------
+    # Pattern → template filename mapping.
+    # Keys are *substrings* matched case-insensitively against the
+    # normalised attack_pattern value.  Order matters – first match wins.
+    # ------------------------------------------------------------------
+    _PATTERN_MAP: List[tuple] = [
+        (("brute_force", "brute-force", "failed_login"), "brute_force_response.yaml.j2"),
+        (("port_scan", "port-scan", "scan"),              "port_scan_response.yaml.j2"),
+        (("credential_reuse", "credential-reuse", "honeytoken"), "credential_reuse_response.yaml.j2"),
+        (("distributed_attack", "distributed-attack", "distributed"), "distributed_attack_response.yaml.j2"),
+    ]
+
+    def __init__(self, templates_dir: Optional[str] = None) -> None:
         if templates_dir is None:
-            # Default to the 'templates' folder relative to this file
             current_dir = os.path.dirname(os.path.abspath(__file__))
             templates_dir = os.path.join(current_dir, "templates")
-        
-        logger.info(f"Initializing PlaybookGenerator with templates directory: {templates_dir}")
-        self.loader = FileSystemLoader(templates_dir)
-        self.env = Environment(loader=self.loader, autoescape=False)
 
-    def _select_template(self, attack_pattern: str) -> str:
-        """
-        Selects the appropriate Jinja2 template file based on the attack_pattern.
-        """
-        if not attack_pattern:
-            raise ValueError("attack_pattern must be provided to select a template.")
-            
-        pattern = attack_pattern.lower().strip()
-        
-        # Mappings matching standard attack patterns to templates
-        if "brute_force" in pattern or "brute-force" in pattern or "failed_login" in pattern:
-            return "brute_force_response.yaml.j2"
-        elif "port_scan" in pattern or "port-scan" in pattern or "scan" in pattern:
-            return "port_scan_response.yaml.j2"
-        elif "credential_reuse" in pattern or "credential-reuse" in pattern or "honeytoken" in pattern:
-            return "credential_reuse_response.yaml.j2"
-        elif "distributed_attack" in pattern or "distributed-attack" in pattern or "distributed" in pattern:
-            return "distributed_attack_response.yaml.j2"
-        else:
-            # Default fallback mapping
-            logger.warning(f"Unknown attack pattern: '{attack_pattern}'. Defaulting to pattern-based template name.")
-            return f"{pattern}_response.yaml.j2"
+        self.templates_dir: str = os.path.abspath(templates_dir)
+        logger.info("Initializing PlaybookGenerator | templates_dir=%s", self.templates_dir)
 
-    def generate(self, context_data: Dict[str, Any]) -> str:
+        # Configure Jinja2 environment with FileSystemLoader
+        self.loader: FileSystemLoader = FileSystemLoader(self.templates_dir)
+        self.env: Environment = Environment(
+            loader=self.loader,
+            autoescape=False,       # YAML output – HTML escaping must be off
+            trim_blocks=True,       # Strip first newline after a block tag
+            lstrip_blocks=True,     # Strip leading whitespace from block tags
+            keep_trailing_newline=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def list_templates(self) -> List[str]:
+        """Return the names of all available ``.yaml.j2`` templates.
+
+        Returns
+        -------
+        list[str]
+            Sorted list of template filenames found in :attr:`templates_dir`.
+
+        Example
+        -------
+        ::
+
+            gen = PlaybookGenerator()
+            print(gen.list_templates())
+            # ['brute_force_response.yaml.j2', 'port_scan_response.yaml.j2', ...]
         """
-        Generates a playbook YAML string by selecting a template based on the 
-        'attack_pattern' parameter in context_data and rendering it.
+        templates = sorted(
+            f for f in self.env.list_templates()
+            if f.endswith(".yaml.j2")
+        )
+        logger.debug("Available templates: %s", templates)
+        return templates
+
+    def validate_context(self, context_data: Dict[str, Any]) -> None:
+        """Validate that *context_data* contains the mandatory ``attack_pattern`` key.
+
+        Parameters
+        ----------
+        context_data:
+            The context dictionary that will be passed to :meth:`generate`.
+
+        Raises
+        ------
+        ValueError
+            If ``attack_pattern`` is missing or evaluates to an empty string.
+        TypeError
+            If *context_data* is not a dictionary.
         """
+        if not isinstance(context_data, dict):
+            raise TypeError(
+                f"context_data must be a dict, got {type(context_data).__name__!r}"
+            )
         attack_pattern = context_data.get("attack_pattern")
         if not attack_pattern:
-            raise ValueError("context_data must contain an 'attack_pattern' key.")
+            raise ValueError(
+                "context_data must contain an 'attack_pattern' key with a non-empty value."
+            )
 
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _select_template(self, attack_pattern: str) -> str:
+        """Select the ``.yaml.j2`` template filename for *attack_pattern*.
+
+        The lookup is case-insensitive.  The first entry in
+        :attr:`_PATTERN_MAP` whose keyword list contains a substring that
+        appears in *attack_pattern* is used.  Unknown patterns fall back to
+        ``{normalised_pattern}_response.yaml.j2``.
+
+        Parameters
+        ----------
+        attack_pattern:
+            Raw attack-pattern string from ``context_data``.
+
+        Returns
+        -------
+        str
+            Template filename (not a full path).
+
+        Raises
+        ------
+        ValueError
+            If *attack_pattern* is empty or *None*.
+        """
+        if not attack_pattern:
+            raise ValueError("attack_pattern must be a non-empty string.")
+
+        pattern = attack_pattern.lower().strip()
+
+        for keywords, template_name in self._PATTERN_MAP:
+            if any(kw in pattern for kw in keywords):
+                logger.debug(
+                    "Pattern %r matched keywords %r → template %r",
+                    attack_pattern, keywords, template_name,
+                )
+                return template_name
+
+        # Graceful fallback – lets callers register custom templates at runtime
+        fallback = f"{pattern}_response.yaml.j2"
+        logger.warning(
+            "Unknown attack pattern %r – falling back to %r. "
+            "Add a template or extend _PATTERN_MAP if this is a new pattern.",
+            attack_pattern, fallback,
+        )
+        return fallback
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+
+    def generate(self, context_data: Dict[str, Any]) -> str:
+        """Generate a playbook YAML string for the given *context_data*.
+
+        This is the primary public interface of the class.  It:
+
+        1. Validates *context_data* via :meth:`validate_context`.
+        2. Selects the appropriate Jinja2 template via :meth:`_select_template`.
+        3. Loads and renders the template, returning the resulting YAML string.
+
+        Parameters
+        ----------
+        context_data:
+            A dictionary of rendering variables.  **Must** include
+            ``attack_pattern`` (``str``).  All other keys are forwarded to
+            the Jinja2 template as context variables.
+
+        Returns
+        -------
+        str
+            Rendered YAML playbook as a string.
+
+        Raises
+        ------
+        ValueError
+            If ``attack_pattern`` is missing from *context_data*.
+        TypeError
+            If *context_data* is not a dictionary.
+        FileNotFoundError
+            If no matching template file is found in :attr:`templates_dir`.
+        jinja2.TemplateError
+            If Jinja2 encounters a rendering error (e.g. invalid template syntax).
+
+        Example
+        -------
+        ::
+
+            gen = PlaybookGenerator()
+            yaml_str = gen.generate({
+                "attack_pattern": "port_scan",
+                "source_ip": "10.0.0.5",
+                "port_count_threshold": 100,
+            })
+        """
+        # --- Step 1: validate input -------------------------------------
+        self.validate_context(context_data)
+        attack_pattern: str = context_data["attack_pattern"]
+
+        # --- Step 2: select template ------------------------------------
         template_name = self._select_template(attack_pattern)
-        logger.info(f"Selected template: {template_name} for attack pattern: {attack_pattern}")
+        logger.info(
+            "Rendering playbook | attack_pattern=%r template=%r",
+            attack_pattern, template_name,
+        )
 
+        # --- Step 3: load template --------------------------------------
         try:
             template = self.env.get_template(template_name)
-        except TemplateNotFound:
-            logger.error(f"Template not found: {template_name}")
-            raise FileNotFoundError(f"Template '{template_name}' not found for attack pattern '{attack_pattern}'")
+        except TemplateNotFound as exc:
+            logger.error("Template not found: %s", template_name)
+            raise FileNotFoundError(
+                f"Template '{template_name}' not found for attack pattern '{attack_pattern}'. "
+                f"Available templates: {self.list_templates()}"
+            ) from exc
 
+        # --- Step 4: render and return ----------------------------------
         try:
-            rendered_yaml = template.render(context_data)
+            rendered_yaml: str = template.render(**context_data)
+            logger.debug("Playbook rendered successfully (%d chars).", len(rendered_yaml))
             return rendered_yaml
-        except Exception as e:
-            logger.error(f"Failed to render template {template_name}: {e}")
+        except Exception as exc:
+            logger.error("Failed to render template %r: %s", template_name, exc)
             raise
+
+    # ------------------------------------------------------------------
+    # Dunder helpers
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"{self.__class__.__name__}("
+            f"templates_dir={self.templates_dir!r}, "
+            f"templates={self.list_templates()!r})"
+        )

--- a/sentinel/templates/brute_force_response.yaml.j2
+++ b/sentinel/templates/brute_force_response.yaml.j2
@@ -1,0 +1,38 @@
+name: "Brute Force Response"
+description: "Triggered when failed logins exceed {{ failed_logins_threshold | default(20) }} within {{ timeframe | default('5 minutes') }}. Action: Block IP, tarpit, alert, and threat intel."
+trigger:
+  type: "failed_login_threshold"
+  condition: "count > {{ failed_logins_threshold | default(20) }}"
+  timeframe: "{{ timeframe_seconds | default('300s') }}"
+
+actions:
+  - name: "block_attacker_ip"
+    type: "block_ip"
+    params:
+      ip: "{{ source_ip | default('${source_ip}') }}"
+      duration: "{{ block_duration | default('3600') }}"
+    rollback: "unblock_ip"
+
+  - name: "tarpit_connection"
+    type: "tarpit"
+    params:
+      ip: "{{ source_ip | default('${source_ip}') }}"
+      delay_ms: {{ tarpit_delay_ms | default(5000) }}
+
+  - name: "alert_security_team"
+    type: "send_alert"
+    params:
+      level: "{{ alert_level | default('HIGH') }}"
+      message: "Brute force attack detected from {{ source_ip | default('${source_ip}') }}. IP has been blocked."
+
+  - name: "query_threat_intel"
+    type: "query_threat_intel"
+    params:
+      ip: "{{ source_ip | default('${source_ip}') }}"
+
+  - name: "create_incident_ticket"
+    type: "create_ticket"
+    params:
+      system: "{{ ticket_system | default('jira') }}"
+      summary: "Brute Force Attack: {{ source_ip | default('${source_ip}') }}"
+      description: "Automated response triggered for brute force attack from IP {{ source_ip | default('${source_ip}') }}."

--- a/sentinel/templates/credential_reuse_response.yaml.j2
+++ b/sentinel/templates/credential_reuse_response.yaml.j2
@@ -1,0 +1,30 @@
+name: "Credential Reuse Detection"
+description: "Triggered when honeytokens are used outside known honeypots. Action: Critical alert, host isolation, and forensics."
+trigger:
+  type: "honeytoken_usage"
+  condition: "location != 'honeypot'"
+
+actions:
+  - name: "critical_ciso_alert"
+    type: "send_alert"
+    params:
+      level: "{{ alert_level | default('CRITICAL') }}"
+      message: "CRITICAL: Honeytoken leakage detected! Credential {{ token_id | default('${token_id}') }} used from {{ source_ip | default('${source_ip}') }} on non-honeypot system."
+
+  - name: "isolate_compromised_systems"
+    type: "isolate_host"
+    params:
+      ip: "{{ target_ip | default('${target_ip}') }}"
+    rollback: "reconnect_host"
+
+  - name: "initiate_full_system_scan"
+    type: "run_scan"
+    params:
+      target: "{{ target_ip | default('${target_ip}') }}"
+      depth: "{{ scan_depth | default('full') }}"
+
+  - name: "start_forensic_analysis"
+    type: "capture_forensics"
+    params:
+      host: "{{ target_ip | default('${target_ip}') }}"
+      artifacts: {{ forensic_artifacts | default(["memory", "process_list", "network_conns"]) | tojson }}

--- a/sentinel/templates/distributed_attack_response.yaml.j2
+++ b/sentinel/templates/distributed_attack_response.yaml.j2
@@ -1,0 +1,36 @@
+name: "Distributed Attack Response"
+description: "Triggered when >{{ distinct_ips_threshold | default(5) }} IPs target the same honeypot. Action: Campaign identification, global blocking, and IOC sharing."
+trigger:
+  type: "distributed_attack_threshold"
+  condition: "distinct_ips > {{ distinct_ips_threshold | default(5) }}"
+  timeframe: "{{ timeframe_seconds | default('600s') }}"
+
+actions:
+  - name: "identify_campaign"
+    type: "correlate_events"
+    params:
+      pattern: "{{ attack_pattern | default('${attack_pattern}') }}"
+
+  - name: "block_campaign_ips"
+    type: "block_ip_list"
+    params:
+      ips: "{{ source_ips | default('${source_ips}') }}"
+      duration: "{{ block_duration | default('86400') }}"
+    rollback: "unblock_ip_list"
+
+  - name: "share_iocs"
+    type: "export_iocs"
+    params:
+      format: "{{ ioc_format | default('STIX') }}"
+      destination: "{{ ioc_destination | default('threat_intel_sharing') }}"
+
+  - name: "escalate_defensive_posture"
+    type: "update_global_policy"
+    params:
+      security_level: "{{ security_level | default('ENHANCED') }}"
+
+  - name: "generate_campaign_report"
+    type: "create_report"
+    params:
+      template: "incident_campaign"
+      output: "reports/distributed_attack_{{ timestamp | default('${timestamp}') }}.md"

--- a/sentinel/templates/port_scan_response.yaml.j2
+++ b/sentinel/templates/port_scan_response.yaml.j2
@@ -1,0 +1,31 @@
+name: "Port Scan Response"
+description: "Triggered when more than {{ port_count_threshold | default(50) }} ports are scanned in {{ timeframe | default('1 minute') }}. Action: Capture packets, deploy honeypots, and alert."
+trigger:
+  type: "port_scan_threshold"
+  condition: "port_count > {{ port_count_threshold | default(50) }}"
+  timeframe: "{{ timeframe_seconds | default('60s') }}"
+
+actions:
+  - name: "capture_attacker_traffic"
+    type: "capture_packets"
+    params:
+      ip: "{{ source_ip | default('${source_ip}') }}"
+      duration: "{{ capture_duration | default('300s') }}"
+
+  - name: "deploy_dynamic_honeypots"
+    type: "deploy_honeypot"
+    params:
+      type: "{{ honeypot_type | default('deception_mesh') }}"
+      count: {{ honeypot_count | default(3) }}
+
+  - name: "activate_aggressive_deception"
+    type: "update_policy"
+    params:
+      target: "honeypots"
+      mode: "{{ deception_mode | default('aggressive_deception') }}"
+
+  - name: "alert_soc"
+    type: "send_alert"
+    params:
+      level: "{{ alert_level | default('HIGH') }}"
+      message: "Port scan detected from {{ source_ip | default('${source_ip}') }}. Deploying honeypots and capturing traffic."

--- a/tests/unit/test_playbook_generator.py
+++ b/tests/unit/test_playbook_generator.py
@@ -1,0 +1,80 @@
+import pytest
+import yaml
+from sentinel.playbook_generator import PlaybookGenerator
+
+def test_playbook_generator_initialization():
+    generator = PlaybookGenerator()
+    assert generator is not None
+    assert generator.env is not None
+
+def test_select_template():
+    generator = PlaybookGenerator()
+    
+    assert generator._select_template("brute_force") == "brute_force_response.yaml.j2"
+    assert generator._select_template("SSH_BRUTE_FORCE_DISTRIBUTED") == "brute_force_response.yaml.j2"
+    assert generator._select_template("port_scan") == "port_scan_response.yaml.j2"
+    assert generator._select_template("credential_reuse") == "credential_reuse_response.yaml.j2"
+    assert generator._select_template("distributed_attack") == "distributed_attack_response.yaml.j2"
+    
+    # Check fallback
+    assert generator._select_template("custom_pattern") == "custom_pattern_response.yaml.j2"
+
+def test_generate_brute_force():
+    generator = PlaybookGenerator()
+    context = {
+        "attack_pattern": "brute_force",
+        "source_ip": "192.168.1.100",
+        "failed_logins_threshold": 30,
+        "timeframe": "10 minutes",
+        "timeframe_seconds": "600s",
+        "block_duration": "7200",
+        "tarpit_delay_ms": 3000,
+        "alert_level": "CRITICAL"
+    }
+    
+    rendered = generator.generate(context)
+    assert rendered is not None
+    
+    # Parse as YAML to verify syntax correctness
+    data = yaml.safe_load(rendered)
+    assert data["name"] == "Brute Force Response"
+    assert "Triggered when failed logins exceed 30" in data["description"]
+    
+    # Check that variables were rendered correctly
+    actions = data["actions"]
+    assert actions[0]["name"] == "block_attacker_ip"
+    assert actions[0]["params"]["ip"] == "192.168.1.100"
+    assert actions[0]["params"]["duration"] == "7200"
+    
+    assert actions[1]["name"] == "tarpit_connection"
+    assert actions[1]["params"]["delay_ms"] == 3000
+    
+    assert actions[2]["params"]["level"] == "CRITICAL"
+
+def test_generate_port_scan():
+    generator = PlaybookGenerator()
+    context = {
+        "attack_pattern": "port_scan",
+        "source_ip": "10.0.0.5",
+        "port_count_threshold": 100,
+        "capture_duration": "600s"
+    }
+    
+    rendered = generator.generate(context)
+    data = yaml.safe_load(rendered)
+    assert data["name"] == "Port Scan Response"
+    
+    actions = data["actions"]
+    assert actions[0]["params"]["ip"] == "10.0.0.5"
+    assert actions[0]["params"]["duration"] == "600s"
+    assert actions[1]["params"]["count"] == 3  # Default value check
+
+def test_generate_missing_pattern():
+    generator = PlaybookGenerator()
+    with pytest.raises(ValueError, match="context_data must contain an 'attack_pattern' key"):
+        generator.generate({"source_ip": "1.1.1.1"})
+
+def test_generate_template_not_found():
+    generator = PlaybookGenerator()
+    with pytest.raises(FileNotFoundError, match="Template 'unknown_pattern_response.yaml.j2' not found"):
+        generator.generate({"attack_pattern": "unknown_pattern"})

--- a/tests/unit/test_playbook_generator.py
+++ b/tests/unit/test_playbook_generator.py
@@ -1,80 +1,260 @@
+"""
+tests/unit/test_playbook_generator.py
+--------------------------------------
+Unit tests for sentinel.playbook_generator.PlaybookGenerator.
+
+Covers:
+- Initialization and Jinja2 environment setup
+- Template selection logic for all supported attack patterns
+- Full render-and-parse cycle for brute_force and port_scan
+- validate_context() guard-rails
+- list_templates() discovery
+- Error paths: missing pattern, unknown template, wrong context type
+"""
+
 import pytest
 import yaml
 from sentinel.playbook_generator import PlaybookGenerator
 
-def test_playbook_generator_initialization():
-    generator = PlaybookGenerator()
-    assert generator is not None
-    assert generator.env is not None
 
-def test_select_template():
-    generator = PlaybookGenerator()
-    
-    assert generator._select_template("brute_force") == "brute_force_response.yaml.j2"
-    assert generator._select_template("SSH_BRUTE_FORCE_DISTRIBUTED") == "brute_force_response.yaml.j2"
-    assert generator._select_template("port_scan") == "port_scan_response.yaml.j2"
-    assert generator._select_template("credential_reuse") == "credential_reuse_response.yaml.j2"
-    assert generator._select_template("distributed_attack") == "distributed_attack_response.yaml.j2"
-    
-    # Check fallback
-    assert generator._select_template("custom_pattern") == "custom_pattern_response.yaml.j2"
+# ============================================================
+# Fixtures
+# ============================================================
 
-def test_generate_brute_force():
-    generator = PlaybookGenerator()
-    context = {
-        "attack_pattern": "brute_force",
-        "source_ip": "192.168.1.100",
-        "failed_logins_threshold": 30,
-        "timeframe": "10 minutes",
-        "timeframe_seconds": "600s",
-        "block_duration": "7200",
-        "tarpit_delay_ms": 3000,
-        "alert_level": "CRITICAL"
-    }
-    
-    rendered = generator.generate(context)
-    assert rendered is not None
-    
-    # Parse as YAML to verify syntax correctness
-    data = yaml.safe_load(rendered)
-    assert data["name"] == "Brute Force Response"
-    assert "Triggered when failed logins exceed 30" in data["description"]
-    
-    # Check that variables were rendered correctly
-    actions = data["actions"]
-    assert actions[0]["name"] == "block_attacker_ip"
-    assert actions[0]["params"]["ip"] == "192.168.1.100"
-    assert actions[0]["params"]["duration"] == "7200"
-    
-    assert actions[1]["name"] == "tarpit_connection"
-    assert actions[1]["params"]["delay_ms"] == 3000
-    
-    assert actions[2]["params"]["level"] == "CRITICAL"
+@pytest.fixture
+def gen() -> PlaybookGenerator:
+    """Return a default PlaybookGenerator instance."""
+    return PlaybookGenerator()
 
-def test_generate_port_scan():
-    generator = PlaybookGenerator()
-    context = {
-        "attack_pattern": "port_scan",
-        "source_ip": "10.0.0.5",
-        "port_count_threshold": 100,
-        "capture_duration": "600s"
-    }
-    
-    rendered = generator.generate(context)
-    data = yaml.safe_load(rendered)
-    assert data["name"] == "Port Scan Response"
-    
-    actions = data["actions"]
-    assert actions[0]["params"]["ip"] == "10.0.0.5"
-    assert actions[0]["params"]["duration"] == "600s"
-    assert actions[1]["params"]["count"] == 3  # Default value check
 
-def test_generate_missing_pattern():
-    generator = PlaybookGenerator()
-    with pytest.raises(ValueError, match="context_data must contain an 'attack_pattern' key"):
-        generator.generate({"source_ip": "1.1.1.1"})
+# ============================================================
+# Initialization
+# ============================================================
 
-def test_generate_template_not_found():
-    generator = PlaybookGenerator()
-    with pytest.raises(FileNotFoundError, match="Template 'unknown_pattern_response.yaml.j2' not found"):
-        generator.generate({"attack_pattern": "unknown_pattern"})
+class TestInit:
+    def test_instance_created(self, gen):
+        assert gen is not None
+
+    def test_jinja2_env_configured(self, gen):
+        assert gen.env is not None
+
+    def test_loader_attached(self, gen):
+        assert gen.loader is not None
+
+    def test_templates_dir_is_absolute(self, gen):
+        import os
+        assert os.path.isabs(gen.templates_dir)
+
+    def test_custom_templates_dir(self, tmp_path):
+        g = PlaybookGenerator(templates_dir=str(tmp_path))
+        assert g.templates_dir == str(tmp_path)
+
+
+# ============================================================
+# Template selection
+# ============================================================
+
+class TestSelectTemplate:
+    @pytest.mark.parametrize("pattern,expected", [
+        ("brute_force",                   "brute_force_response.yaml.j2"),
+        ("brute-force",                   "brute_force_response.yaml.j2"),
+        ("failed_login",                  "brute_force_response.yaml.j2"),
+        ("SSH_BRUTE_FORCE_DISTRIBUTED",   "brute_force_response.yaml.j2"),
+        ("port_scan",                     "port_scan_response.yaml.j2"),
+        ("port-scan",                     "port_scan_response.yaml.j2"),
+        ("scan",                          "port_scan_response.yaml.j2"),
+        ("credential_reuse",              "credential_reuse_response.yaml.j2"),
+        ("credential-reuse",              "credential_reuse_response.yaml.j2"),
+        ("honeytoken",                    "credential_reuse_response.yaml.j2"),
+        ("distributed_attack",            "distributed_attack_response.yaml.j2"),
+        ("distributed-attack",            "distributed_attack_response.yaml.j2"),
+        ("distributed",                   "distributed_attack_response.yaml.j2"),
+    ])
+    def test_known_patterns(self, gen, pattern, expected):
+        assert gen._select_template(pattern) == expected
+
+    def test_fallback_unknown_pattern(self, gen):
+        assert gen._select_template("custom_pattern") == "custom_pattern_response.yaml.j2"
+
+    def test_empty_pattern_raises(self, gen):
+        with pytest.raises(ValueError):
+            gen._select_template("")
+
+    def test_none_pattern_raises(self, gen):
+        with pytest.raises((ValueError, AttributeError)):
+            gen._select_template(None)
+
+
+# ============================================================
+# validate_context
+# ============================================================
+
+class TestValidateContext:
+    def test_valid_context_passes(self, gen):
+        gen.validate_context({"attack_pattern": "brute_force"})
+
+    def test_missing_attack_pattern_raises(self, gen):
+        with pytest.raises(ValueError, match="attack_pattern"):
+            gen.validate_context({"source_ip": "1.1.1.1"})
+
+    def test_empty_attack_pattern_raises(self, gen):
+        with pytest.raises(ValueError, match="attack_pattern"):
+            gen.validate_context({"attack_pattern": ""})
+
+    def test_non_dict_raises(self, gen):
+        with pytest.raises(TypeError):
+            gen.validate_context(["attack_pattern", "brute_force"])
+
+
+# ============================================================
+# list_templates
+# ============================================================
+
+class TestListTemplates:
+    def test_returns_list(self, gen):
+        templates = gen.list_templates()
+        assert isinstance(templates, list)
+
+    def test_all_yaml_j2(self, gen):
+        for t in gen.list_templates():
+            assert t.endswith(".yaml.j2")
+
+    def test_expected_templates_present(self, gen):
+        templates = gen.list_templates()
+        assert "brute_force_response.yaml.j2" in templates
+        assert "port_scan_response.yaml.j2" in templates
+        assert "credential_reuse_response.yaml.j2" in templates
+        assert "distributed_attack_response.yaml.j2" in templates
+
+    def test_sorted_order(self, gen):
+        templates = gen.list_templates()
+        assert templates == sorted(templates)
+
+
+# ============================================================
+# generate() – brute_force
+# ============================================================
+
+class TestGenerateBruteForce:
+    def test_returns_non_empty_string(self, gen):
+        rendered = gen.generate({
+            "attack_pattern": "brute_force",
+            "source_ip": "192.168.1.100",
+        })
+        assert isinstance(rendered, str)
+        assert len(rendered) > 0
+
+    def test_valid_yaml_output(self, gen):
+        rendered = gen.generate({
+            "attack_pattern": "brute_force",
+            "source_ip": "192.168.1.100",
+        })
+        data = yaml.safe_load(rendered)
+        assert isinstance(data, dict)
+
+    def test_variables_substituted(self, gen):
+        context = {
+            "attack_pattern": "brute_force",
+            "source_ip": "192.168.1.100",
+            "failed_logins_threshold": 30,
+            "timeframe": "10 minutes",
+            "timeframe_seconds": "600s",
+            "block_duration": "7200",
+            "tarpit_delay_ms": 3000,
+            "alert_level": "CRITICAL",
+        }
+        data = yaml.safe_load(gen.generate(context))
+        assert data["name"] == "Brute Force Response"
+        assert "Triggered when failed logins exceed 30" in data["description"]
+
+        actions = data["actions"]
+        assert actions[0]["name"] == "block_attacker_ip"
+        assert actions[0]["params"]["ip"] == "192.168.1.100"
+        assert actions[0]["params"]["duration"] == "7200"
+        assert actions[1]["name"] == "tarpit_connection"
+        assert actions[1]["params"]["delay_ms"] == 3000
+        assert actions[2]["params"]["level"] == "CRITICAL"
+
+    def test_default_values_applied(self, gen):
+        # Only the required key – all others should use Jinja2 defaults
+        data = yaml.safe_load(gen.generate({"attack_pattern": "brute_force"}))
+        actions = data["actions"]
+        assert actions[0]["params"]["duration"] == "3600"
+        assert actions[2]["params"]["level"] == "HIGH"
+
+
+# ============================================================
+# generate() – port_scan
+# ============================================================
+
+class TestGeneratePortScan:
+    def test_correct_name(self, gen):
+        data = yaml.safe_load(gen.generate({
+            "attack_pattern": "port_scan",
+            "source_ip": "10.0.0.5",
+            "port_count_threshold": 100,
+            "capture_duration": "600s",
+        }))
+        assert data["name"] == "Port Scan Response"
+
+    def test_ip_rendered(self, gen):
+        data = yaml.safe_load(gen.generate({
+            "attack_pattern": "port_scan",
+            "source_ip": "10.0.0.5",
+            "capture_duration": "600s",
+        }))
+        assert data["actions"][0]["params"]["ip"] == "10.0.0.5"
+        assert data["actions"][0]["params"]["duration"] == "600s"
+
+    def test_default_honeypot_count(self, gen):
+        data = yaml.safe_load(gen.generate({"attack_pattern": "port_scan"}))
+        assert data["actions"][1]["params"]["count"] == 3
+
+
+# ============================================================
+# generate() – credential_reuse
+# ============================================================
+
+class TestGenerateCredentialReuse:
+    def test_correct_name(self, gen):
+        data = yaml.safe_load(gen.generate({"attack_pattern": "credential_reuse"}))
+        assert data["name"] == "Credential Reuse Detection"
+
+    def test_default_alert_level_critical(self, gen):
+        data = yaml.safe_load(gen.generate({"attack_pattern": "honeytoken"}))
+        assert data["actions"][0]["params"]["level"] == "CRITICAL"
+
+
+# ============================================================
+# generate() – distributed_attack
+# ============================================================
+
+class TestGenerateDistributedAttack:
+    def test_correct_name(self, gen):
+        data = yaml.safe_load(gen.generate({"attack_pattern": "distributed_attack"}))
+        assert data["name"] == "Distributed Attack Response"
+
+    def test_default_ioc_format(self, gen):
+        data = yaml.safe_load(gen.generate({"attack_pattern": "distributed"}))
+        share_action = next(
+            a for a in data["actions"] if a["name"] == "share_iocs"
+        )
+        assert share_action["params"]["format"] == "STIX"
+
+
+# ============================================================
+# Error paths
+# ============================================================
+
+class TestErrorPaths:
+    def test_missing_attack_pattern_raises_value_error(self, gen):
+        with pytest.raises(ValueError, match="attack_pattern"):
+            gen.generate({"source_ip": "1.1.1.1"})
+
+    def test_unknown_pattern_raises_file_not_found(self, gen):
+        with pytest.raises(FileNotFoundError, match="unknown_pattern_response.yaml.j2"):
+            gen.generate({"attack_pattern": "unknown_pattern"})
+
+    def test_non_dict_context_raises_type_error(self, gen):
+        with pytest.raises(TypeError):
+            gen.generate("not_a_dict")


### PR DESCRIPTION
## Summary
Implements the sentinel/playbook_generator.py scaffold as described in the sprint task.

---

## What changed

### sentinel/playbook_generator.py
- **Jinja2 Environment** configured with FileSystemLoader pointing at sentinel/templates/
  - 	rim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True
- **PlaybookGenerator class**
  - __init__(templates_dir=None) – resolves to sentinel/templates/ by default
  - generate(context_data) – selects template, validates input, renders and returns YAML string
  - _select_template(attack_pattern) – maps attack patterns to .yaml.j2 templates via _PATTERN_MAP
  - alidate_context(context_data) – raises ValueError / TypeError on bad input early
  - list_templates() – returns sorted list of available .yaml.j2 templates
  - __repr__ – developer-friendly string representation
- Full module-level docstring with usage example and pattern→template table

### Attack pattern → template mapping
| Pattern keyword(s) | Template |
|---|---|
| rute_force, rute-force, ailed_login | rute_force_response.yaml.j2 |
| port_scan, port-scan, scan | port_scan_response.yaml.j2 |
| credential_reuse, credential-reuse, honeytoken | credential_reuse_response.yaml.j2 |
| distributed_attack, distributed-attack, distributed | distributed_attack_response.yaml.j2 |
| *anything else* | {pattern}_response.yaml.j2 (fallback) |

### 	ests/unit/test_playbook_generator.py
Expanded from 5 to **43 tests** across 8 test classes:
- TestInit – constructor and environment setup
- TestSelectTemplate – parametrized over 13 pattern variants + fallback + error paths
- TestValidateContext – all guard-rails
- TestListTemplates – discovery, sort order, file extension filter
- TestGenerateBruteForce – render+parse cycle, variable substitution, default values
- TestGeneratePortScan – IP injection, default honeypot count
- TestGenerateCredentialReuse – name check, CRITICAL default
- TestGenerateDistributedAttack – name check, STIX default
- TestErrorPaths – missing pattern, unknown template, wrong type

## Test results
\\\
43 passed in 0.71s
\\\

## Checklist
- [x] Jinja2 Environment + FileSystemLoader → sentinel/templates/
- [x] generate(context_data) method implemented
- [x] Template selection logic based on ttack_pattern
- [x] alidate_context() guard-rails
- [x] list_templates() helper
- [x] 43 unit tests – all passing
- [x] Conventional-commit message
