### PR TITLE
feat(sentinel): complete SentinelService orchestrator — Week 14 Day 1

### DIFF
--- a/backend/sentinel/sentinel_service.py
+++ b/backend/sentinel/sentinel_service.py
@@ -28,11 +28,14 @@ Public API
     SentinelService(db_session)
         Instantiate with a SQLAlchemy session.
 
-    generate_playbook(campaign_data) -> dict
-        Full pipeline: infer → query → map → generate rules → build STIX
-        → render playbook → persist SentinelPlaybook row → return result dict.
+    SentinelService.create_and_run(campaign_data) -> SentinelPlaybook
+        Class-level convenience: creates session, runs pipeline, closes session.
 
-Phase 5, Week 1, Day 5 — Issue #673
+    generate_playbook(campaign_data) -> SentinelPlaybook
+        Full pipeline: infer → query → map → generate rules → build STIX
+        → render playbook → persist SentinelPlaybook row → return ORM object.
+
+Phase 5, Week 2 (Week 14), Day 1 — Integration & API
 """
 
 from __future__ import annotations
@@ -54,8 +57,9 @@ from sentinel.rule_generator import (
 from sentinel.stix_enhanced import build_stix_bundle, bundle_to_json
 from sentinel.models import SentinelPlaybook
 
-# Database models
-from database.models import PacketLog, Event
+# Database models and session
+from database.models import PacketLog, Event, IOC
+from database.database import SessionLocal
 
 # ML signature engine
 from ml.signatures import SignatureEngine
@@ -131,17 +135,76 @@ class SentinelService:
     # ------------------------------------------------------------------
     @property
     def playbook_gen(self):
-        """Lazy-load PlaybookGenerator to avoid import-time side effects."""
+        """Lazy-load PlaybookGenerator to avoid import-time side effects.
+
+        Attempts import from backend/sentinel first, then falls back to
+        the root sentinel package where PlaybookGenerator and its Jinja2
+        templates actually reside.
+        """
         if self._playbook_gen is None:
             try:
                 from sentinel.playbook_generator import PlaybookGenerator
                 self._playbook_gen = PlaybookGenerator()
-            except ImportError:
-                logger.warning(
-                    "PlaybookGenerator not available — playbook rendering "
-                    "will return a placeholder."
-                )
+            except (ImportError, Exception):
+                # Fallback: root-level sentinel package has the generator
+                try:
+                    import os, sys
+                    root_dir = os.path.abspath(
+                        os.path.join(os.path.dirname(__file__), "..", "..")
+                    )
+                    if root_dir not in sys.path:
+                        sys.path.insert(0, root_dir)
+                    # Import from root sentinel package
+                    from importlib import import_module
+                    mod = import_module("sentinel.playbook_generator")
+                    PlaybookGenerator = mod.PlaybookGenerator
+                    self._playbook_gen = PlaybookGenerator()
+                    logger.info(
+                        "PlaybookGenerator loaded from root sentinel package"
+                    )
+                except Exception:
+                    logger.warning(
+                        "PlaybookGenerator not available — playbook rendering "
+                        "will return a placeholder."
+                    )
         return self._playbook_gen
+
+    # ------------------------------------------------------------------
+    # Class-level convenience: session lifecycle management
+    # ------------------------------------------------------------------
+    @classmethod
+    def create_and_run(
+        cls, campaign_data: Dict[str, Any]
+    ) -> SentinelPlaybook:
+        """Create a DB session, run the full pipeline, close the session.
+
+        This is the recommended entry point for callers that do not
+        already hold an open SQLAlchemy session.  The session is
+        created from the existing ``SessionLocal`` factory, used for
+        the entire pipeline, and closed in the ``finally`` block.
+
+        Args:
+            campaign_data: Campaign clustering output dict.
+
+        Returns:
+            The persisted SentinelPlaybook ORM object (detached from
+            the now-closed session — all attributes are eagerly loaded
+            before close).
+
+        Raises:
+            Exception: Re-raises any pipeline error after session cleanup.
+        """
+        db = SessionLocal()
+        try:
+            svc = cls(db)
+            playbook = svc.generate_playbook(campaign_data)
+            return playbook
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+            logger.info("DB session closed (create_and_run)")
 
     # ------------------------------------------------------------------
     # Step 1: Infer service type from target ports
@@ -232,10 +295,68 @@ class SentinelService:
 
         results = query.order_by(PacketLog.timestamp.desc()).limit(500).all()
         logger.info(
-            "PacketLog query: %d rows matched (ips=%d, ports=%s)",
+            "PacketLog query: %d rows matched (ips=%d, ports=%s, time_range=%s)",
             len(results), len(source_ips), int_ports,
+            "yes" if time_range else "no",
         )
         return results
+
+    # ------------------------------------------------------------------
+    # Step 2b: Query IOC table for enrichment
+    # ------------------------------------------------------------------
+    def _query_iocs(
+        self,
+        source_ips: List[str],
+    ) -> List[Any]:
+        """Query the IOC table for entries matching the campaign's source IPs.
+
+        This enriches the pipeline with threat intelligence previously
+        ingested into the IOC table (IP-type indicators, watchlist flags,
+        threat_level ratings).
+
+        Args:
+            source_ips: List of attacker source IP strings.
+
+        Returns:
+            List of matching IOC ORM objects.
+        """
+        if not source_ips:
+            return []
+
+        try:
+            ioc_rows = (
+                self.db.query(IOC)
+                .filter(
+                    IOC.type == "IP",
+                    IOC.value.in_(source_ips),
+                )
+                .all()
+            )
+            logger.info(
+                "IOC query: %d rows matched for %d source IPs",
+                len(ioc_rows), len(source_ips),
+            )
+            return ioc_rows
+        except Exception as exc:
+            logger.warning("IOC query failed: %s — continuing without IOC enrichment", exc)
+            return []
+
+    # ------------------------------------------------------------------
+    # Derive max threat_level string from IOC rows
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _max_ioc_threat_level(ioc_rows: List[Any]) -> Optional[str]:
+        """Return the highest threat_level from matched IOC rows."""
+        level_order = {"Low": 1, "Medium": 2, "High": 3, "Critical": 4}
+        best_level = None
+        best_rank = 0
+        for ioc in ioc_rows:
+            lvl = getattr(ioc, "threat_level", None) or "Medium"
+            rank = level_order.get(lvl, 2)
+            if rank > best_rank:
+                best_rank = rank
+                best_level = lvl
+        return best_level
 
     # ------------------------------------------------------------------
     # Step 3: Run SignatureEngine on events for matched IPs
@@ -349,12 +470,13 @@ class SentinelService:
     # ------------------------------------------------------------------
     # Core public API: generate_playbook()
     # ------------------------------------------------------------------
-    def generate_playbook(self, campaign_data: Dict[str, Any]) -> Dict[str, Any]:
+    def generate_playbook(self, campaign_data: Dict[str, Any]) -> SentinelPlaybook:
         """Full Sentinel pipeline for a single campaign cluster.
 
-        Performs the 4-step inference process:
+        Performs the complete inference and generation process:
           1. Infer service from target_ports
           2. Query PacketLog for matching IPs + timestamps → threat_levels
+          2b. Query IOC table for threat intelligence enrichment
           3. Run SignatureEngine on events → detected signature names
           4. Map signatures via mitre_mapper → ATT&CK technique
           5. Generate Snort/Sigma rules via rule_generator
@@ -373,15 +495,9 @@ class SentinelService:
                 - campaign_id:  str (optional)
 
         Returns:
-            Dict with all generated artefacts:
-                - playbook_id, campaign_id
-                - service_type, attack_type, protocol
-                - technique (MITRE ATT&CK dict)
-                - snort_rule, sigma_rule
-                - stix_bundle_json
-                - playbook_content, playbook_name, template_name
-                - threat_score
-                - matched_logs_count, signatures_stored_count
+            SentinelPlaybook ORM object persisted in the database.
+            The object carries a ``result_dict`` attribute with all
+            generated artefacts for convenience.
         """
         logger.info("═" * 60)
         logger.info("SentinelService.generate_playbook() — START")
@@ -421,6 +537,15 @@ class SentinelService:
         matched_logs = self._query_packet_logs(source_ips, normalised_ports, time_range)
         threat_score = self._avg_threat_score(matched_logs)
         logger.info("Step 2 — Matched %d PacketLog rows, avg threat_score=%.2f", len(matched_logs), threat_score)
+
+        # ── Step 2b: Query IOC table for enrichment ───────────────────────
+        ioc_rows = self._query_iocs(source_ips)
+        ioc_threat_level = self._max_ioc_threat_level(ioc_rows)
+        if ioc_threat_level:
+            logger.info("Step 2b — IOC enrichment: %d IOCs, max threat_level=%s",
+                        len(ioc_rows), ioc_threat_level)
+        else:
+            logger.info("Step 2b — No IOC matches found for source IPs")
 
         # ── Step 3: Run SignatureEngine on events ─────────────────────────
         signature_names = self._run_signature_analysis(source_ips, service_type)
@@ -468,17 +593,31 @@ class SentinelService:
                      rules_result["metadata"]["sigma_rule_count"])
 
         # ── Step 6: Build STIX 2.1 bundle ─────────────────────────────────
+        # Merge source IPs as IOCs + any IOC table entries
         iocs = [{"type": "ip", "value": ip} for ip in source_ips]
+        for ioc_row in ioc_rows:
+            ioc_entry = {"type": ioc_row.type.lower(), "value": ioc_row.value}
+            if ioc_entry not in iocs:
+                iocs.append(ioc_entry)
         src_ip_primary = source_ips[0] if source_ips else None
+
+        # Use IOC threat_level to influence TLP if available
+        if ioc_threat_level in ("Critical", "High") or threat_score >= 70:
+            tlp = "amber"
+        elif ioc_threat_level == "Medium" or threat_score >= 40:
+            tlp = "green"
+        else:
+            tlp = "green"
+
         stix_bundle = build_stix_bundle(
             technique=primary_technique,
             iocs=iocs,
             src_ip=src_ip_primary,
             threat_score=threat_score,
-            tlp_level="amber" if threat_score >= 70 else "green",
+            tlp_level=tlp,
         )
         stix_json = bundle_to_json(stix_bundle, pretty=True)
-        logger.info("Step 6 — STIX bundle: %d objects", len(stix_bundle.objects))
+        logger.info("Step 6 — STIX bundle: %d objects, tlp=%s", len(stix_bundle.objects), tlp)
 
         # ── Step 7: Render playbook ───────────────────────────────────────
         playbook_name = f"{service_type} {primary_technique.get('technique_name', 'Response')} Playbook"
@@ -578,8 +717,8 @@ class SentinelService:
         logger.info("SentinelService.generate_playbook() — COMPLETE")
         logger.info("═" * 60)
 
-        # ── Return result dict ────────────────────────────────────────────
-        return {
+        # ── Attach result_dict for convenience ────────────────────────────
+        playbook_record.result_dict = {
             "playbook_id": playbook_id,
             "campaign_id": campaign_id,
             "service_type": service_type,
@@ -599,8 +738,12 @@ class SentinelService:
             "playbook_content": playbook_content,
             "template_name": template_name,
             "threat_score": threat_score,
+            "ioc_threat_level": ioc_threat_level,
+            "ioc_count": len(ioc_rows),
             "matched_logs_count": len(matched_logs),
             "signatures_stored_count": sigs_stored,
             "detected_signatures": signature_names,
             "db_record_id": playbook_record.id,
         }
+
+        return playbook_record

--- a/tests/verify_sentinel_service.py
+++ b/tests/verify_sentinel_service.py
@@ -1,4 +1,20 @@
-"""Verify SentinelService — 8-point test suite."""
+"""
+Verify SentinelService — Week 14 Day 1 — 12-point test suite.
+
+Tests:
+  1. Port-to-service mapping
+  2. Default signature mapping
+  3. Playbook ID format
+  4. Instantiation with DB session
+  5. Service inference
+  6. generate_playbook callable
+  7. Full pipeline returns SentinelPlaybook ORM object
+  8. DB row persisted correctly
+  9. result_dict attached with all artefacts
+ 10. IOC query integration
+ 11. create_and_run classmethod (session lifecycle)
+ 12. Multi-protocol campaign (HTTP)
+"""
 import sys
 sys.path.insert(0, "backend")
 
@@ -8,9 +24,10 @@ from sentinel.sentinel_service import (
     _SERVICE_DEFAULT_SIGNATURE,
     _generate_playbook_id,
 )
+from sentinel.models import SentinelPlaybook
 
 # Ensure tables exist
-from database.database import engine
+from database.database import engine, SessionLocal
 from database.models import Base
 from sentinel.models import SentinelPlaybook as _SP  # noqa: F401
 Base.metadata.create_all(bind=engine)
@@ -21,28 +38,27 @@ assert _PORT_SERVICE_MAP[2222] == "SSH"
 assert _PORT_SERVICE_MAP[8080] == "HTTP"
 assert _PORT_SERVICE_MAP[2121] == "FTP"
 assert _PORT_SERVICE_MAP[2525] == "SMTP"
-print("Test 1 PASS: Port-to-service mapping correct")
+print("Test 1  PASS: Port-to-service mapping correct")
 
 # Test 2: Default signatures
 assert _SERVICE_DEFAULT_SIGNATURE["SSH"] == "SSH_AUTH_FAILURE"
 assert _SERVICE_DEFAULT_SIGNATURE["HTTP"] == "HTTP_SCANNER_BEHAVIOR"
 assert _SERVICE_DEFAULT_SIGNATURE["FTP"] == "FTP_DATA_EXFILTRATION"
 assert _SERVICE_DEFAULT_SIGNATURE["SMTP"] == "SMTP_LARGE_PAYLOAD"
-print("Test 2 PASS: Default signature mapping correct")
+print("Test 2  PASS: Default signature mapping correct")
 
 # Test 3: Playbook ID format
 pb_id = _generate_playbook_id()
 assert pb_id.startswith("PB-")
 assert len(pb_id) == 25
-print(f"Test 3 PASS: Playbook ID generated: {pb_id}")
+print(f"Test 3  PASS: Playbook ID generated: {pb_id}")
 
 # Test 4: Instantiation
-from database.database import SessionLocal
 db = SessionLocal()
 svc = SentinelService(db)
 assert svc.db is db
 assert svc.sig_engine is not None
-print("Test 4 PASS: SentinelService instantiated with DB session")
+print("Test 4  PASS: SentinelService instantiated with DB session")
 
 # Test 5: Service inference
 assert svc._infer_service([2222]) == "SSH"
@@ -51,13 +67,13 @@ assert svc._infer_service([2121]) == "FTP"
 assert svc._infer_service([2525]) == "SMTP"
 assert svc._infer_service([9999]) == "UNKNOWN"
 assert svc._infer_service([9999, 2222]) == "SSH"
-print("Test 5 PASS: Service inference works correctly")
+print("Test 5  PASS: Service inference works correctly")
 
 # Test 6: generate_playbook callable
 assert callable(svc.generate_playbook)
-print("Test 6 PASS: generate_playbook is callable")
+print("Test 6  PASS: generate_playbook is callable")
 
-# Test 7: Full pipeline
+# Test 7: Full pipeline returns SentinelPlaybook ORM object
 result = svc.generate_playbook({
     "source_ips": ["10.0.0.99"],
     "target_ports": [2222],
@@ -65,35 +81,101 @@ result = svc.generate_playbook({
     "event_count": 150,
     "campaign_id": "TEST-CAMP-001",
 })
-assert result["playbook_id"].startswith("PB-")
-assert result["service_type"] == "SSH"
-assert result["attack_type"] == "SSH_AUTH_FAILURE"
-assert result["technique"]["id"] == "T1110.001"
-assert result["technique"]["tactic"] == "Credential Access"
-assert result["snort_rule"]
-assert result["sigma_rule"]
-assert result["stix_bundle_json"]
-assert result["playbook_content"]
-assert result["playbook_name"]
-assert result["db_record_id"] > 0
-pid = result["playbook_id"]
-print(f"Test 7 PASS: Full pipeline OK (playbook_id={pid})")
+assert isinstance(result, SentinelPlaybook), \
+    f"Expected SentinelPlaybook, got {type(result).__name__}"
+assert result.playbook_id.startswith("PB-")
+assert result.attack_type == "SSH_AUTH_FAILURE"
+assert result.technique_id == "T1110.001"
+assert result.tactic == "Credential Access"
+assert result.status == "pending"
+assert result.id > 0
+pid = result.playbook_id
+print(f"Test 7  PASS: Full pipeline returns SentinelPlaybook (playbook_id={pid})")
 
 # Test 8: DB row persisted
-from sentinel.models import SentinelPlaybook
 row = db.query(SentinelPlaybook).filter_by(playbook_id=pid).first()
 assert row is not None
 assert row.technique_id == "T1110.001"
 assert row.attack_type == "SSH_AUTH_FAILURE"
 assert row.status == "pending"
-print(f"Test 8 PASS: SentinelPlaybook DB row verified (id={row.id})")
+assert row.snort_rule is not None and len(row.snort_rule) > 0
+assert row.sigma_rule is not None and len(row.sigma_rule) > 0
+assert row.playbook_content is not None and len(row.playbook_content) > 0
+assert row.playbook_name is not None
+print(f"Test 8  PASS: SentinelPlaybook DB row verified (id={row.id})")
 
-# Cleanup
+# Test 9: result_dict attached with all artefacts
+rd = result.result_dict
+assert rd["playbook_id"] == pid
+assert rd["campaign_id"] == "TEST-CAMP-001"
+assert rd["service_type"] == "SSH"
+assert rd["attack_type"] == "SSH_AUTH_FAILURE"
+assert rd["technique"]["id"] == "T1110.001"
+assert rd["technique"]["tactic"] == "Credential Access"
+assert rd["snort_rule"]
+assert rd["sigma_rule"]
+assert rd["stix_bundle_json"]
+assert rd["playbook_content"]
+assert rd["playbook_name"]
+assert rd["db_record_id"] > 0
+assert "ioc_count" in rd
+assert "ioc_threat_level" in rd
+assert "matched_logs_count" in rd
+assert "signatures_stored_count" in rd
+assert "detected_signatures" in rd
+print("Test 9  PASS: result_dict attached with all required artefacts")
+
+# Test 10: IOC query integration
+ioc_results = svc._query_iocs(["10.0.0.99"])
+assert isinstance(ioc_results, list)
+print(f"Test 10 PASS: IOC query integration works ({len(ioc_results)} IOCs found)")
+
+# Cleanup test 7 row
 db.delete(row)
 db.commit()
+
+# Test 11: create_and_run classmethod (session lifecycle)
+playbook = SentinelService.create_and_run({
+    "source_ips": ["192.168.1.50"],
+    "target_ports": [8080],
+    "protocols": ["TCP"],
+    "event_count": 75,
+    "campaign_id": "TEST-CAMP-002",
+})
+assert isinstance(playbook, SentinelPlaybook)
+assert playbook.playbook_id.startswith("PB-")
+assert playbook.technique_id is not None
+assert playbook.id > 0
+# Verify it was persisted (use a fresh session)
+db2 = SessionLocal()
+row2 = db2.query(SentinelPlaybook).filter_by(playbook_id=playbook.playbook_id).first()
+assert row2 is not None
+assert row2.status == "pending"
+db2.delete(row2)
+db2.commit()
+db2.close()
+print(f"Test 11 PASS: create_and_run lifecycle OK (playbook_id={playbook.playbook_id})")
+
+# Test 12: Multi-protocol campaign (HTTP)
+result_http = svc.generate_playbook({
+    "source_ips": ["172.16.0.10"],
+    "target_ports": [8080],
+    "protocols": ["TCP"],
+    "event_count": 200,
+    "campaign_id": "TEST-CAMP-HTTP",
+})
+assert isinstance(result_http, SentinelPlaybook)
+assert result_http.technique_id is not None
+rd_http = result_http.result_dict
+assert rd_http["service_type"] == "HTTP"
+# Cleanup
+db.delete(result_http)
+db.commit()
+print(f"Test 12 PASS: HTTP campaign pipeline OK (service=HTTP)")
+
 db.close()
 
 print()
-print("=" * 50)
-print("ALL 8 TESTS PASSED — SentinelService verified!")
-print("=" * 50)
+print("=" * 55)
+print("ALL 12 TESTS PASSED — SentinelService W14D1 verified!")
+print("=" * 55)


### PR DESCRIPTION
- generate_playbook() now returns SentinelPlaybook ORM object
- Add DB session lifecycle via create_and_run() classmethod (SessionLocal)
- Add IOC table enrichment (Step 2b) with threat_level-aware TLP
- Fix PlaybookGenerator import with root sentinel package fallback
- Wire full pipeline: mapper -> generator -> rules -> stix -> DB save
- Store detected_signatures in PacketLog rows (Step 9)
- Infer protocol from target_ports (2222->SSH, 8080->HTTP, 2121->FTP, 2525->SMTP)
- Query PacketLog for matching IPs+timestamps for threat_levels
- Query events table for raw_data to run SignatureEngine.check_signatures()
- Expand verification test suite from 8 to 12 tests (all pass)
- Remove empty week14_config.json placeholder

Closes: Week 14 Day 1 tasks
No modifications to threat_analyzer.py