### PR TITLE
fix(sentinel): use positional arguments in generate_rules_for_campaig…

### DIFF
--- a/backend/sentinel/sentinel_service.py
+++ b/backend/sentinel/sentinel_service.py
@@ -581,8 +581,8 @@ class SentinelService:
 
         # ── Step 5: Generate Snort/Sigma rules ────────────────────────────
         rules_result = generate_rules_for_campaign(
-            cluster_data=campaign_data,
-            mitre_info=techniques if techniques else primary_technique,
+            campaign_data,
+            techniques if techniques else primary_technique,
         )
         snort_rule = rules_result.get("snort_rules", "")
         sigma_rule = rules_result.get("sigma_rules", "")


### PR DESCRIPTION
…n call

- Changed keyword arguments to positional arguments (campaign_data, primary_technique) in generate_rules_for_campaign call.
- This fixes conflicts in VS Code's editor between backend/sentinel/rule_generator.py (which uses cluster_data/mitre_info) and the root sentinel/rule_generator.py (which uses cluster/mitre).
- Cleaned up the Pylance/Pylint parameter mismatches/errors.