### PR TITLE
feat(sentinel): add 5 new API endpoints — approve, reject, export, sn…

### DIFF
--- a/backend/api/sentinel.py
+++ b/backend/api/sentinel.py
@@ -3,27 +3,36 @@ backend/api/sentinel.py
 -------------------------
 PhantomNet Sentinel Layer — REST API Endpoints
 
-Provides 5 endpoints for the Sentinel Dashboard:
+Provides 10 endpoints for the Sentinel Dashboard:
 
-  GET  /api/sentinel/playbooks          — List all playbooks (paginated)
-  GET  /api/sentinel/playbooks/{id}     — Get single playbook by ID
-  GET  /api/sentinel/stats              — Playbook pipeline statistics
-  GET  /api/sentinel/mitre/mapping      — All 12 ATT&CK technique mappings
-  POST /api/sentinel/generate           — Trigger manual playbook generation
+  GET   /api/sentinel/playbooks              — List all playbooks (paginated)
+  GET   /api/sentinel/playbooks/{id}         — Get single playbook by ID
+  GET   /api/sentinel/stats                  — Playbook pipeline statistics
+  GET   /api/sentinel/mitre/mapping          — All 12 ATT&CK technique mappings
+  POST  /api/sentinel/generate               — Trigger manual playbook generation
+  PATCH /api/sentinel/playbooks/{id}/approve — Approve a playbook
+  PATCH /api/sentinel/playbooks/{id}/reject  — Reject a playbook
+  POST  /api/sentinel/playbooks/{id}/export  — Export playbook as file download
+  GET   /api/sentinel/rules/snort            — List all Snort rules
+  GET   /api/sentinel/rules/sigma            — List all Sigma rules
 
 Router prefix: /api/sentinel
 Tags: ['Sentinel']
 
-Week 14, Day 2 — Integration & API
+Week 14, Day 2 + Day 3 — Integration & API
 """
 
 from __future__ import annotations
 
+import io
+import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -100,6 +109,24 @@ class GenerateResponse(BaseModel):
     technique_name: Optional[str] = None
     threat_score: float
     message: str
+
+
+class ReviewRequest(BaseModel):
+    """Request body for PATCH /approve and /reject endpoints."""
+    reviewed_by: str = Field(
+        ...,
+        min_length=1,
+        max_length=128,
+        description="Username of the analyst performing the review",
+    )
+
+    @field_validator("reviewed_by")
+    @classmethod
+    def validate_reviewed_by(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("reviewed_by must not be empty or whitespace")
+        return v
 
 
 # ---------------------------------------------------------------------------
@@ -352,3 +379,356 @@ def generate_playbook(
     except Exception as exc:
         logger.error("Playbook generation failed: %s", exc)
         raise HTTPException(status_code=500, detail=f"Playbook generation failed: {str(exc)}")
+
+
+# ---------------------------------------------------------------------------
+# 6. PATCH /api/sentinel/playbooks/{id}/approve — Approve a playbook
+# ---------------------------------------------------------------------------
+
+@router.patch("/playbooks/{playbook_id}/approve", response_model=Dict[str, Any])
+def approve_playbook(
+    playbook_id: int = Path(..., ge=1, description="Database ID of the playbook to approve"),
+    body: ReviewRequest = ...,
+    db: Session = Depends(get_db),
+):
+    """
+    Approve a Sentinel playbook.
+
+    Updates **three** fields atomically:
+      - ``status`` → ``"approved"``
+      - ``reviewed_by`` → analyst username from request body
+      - ``reviewed_at`` → current UTC timestamp
+
+    Only playbooks with status ``"pending"`` can be approved.
+    """
+    row = db.query(SentinelPlaybook).filter(SentinelPlaybook.id == playbook_id).first()
+    if not row:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Playbook with id={playbook_id} not found",
+        )
+
+    if row.status not in ("pending", "rejected"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot approve playbook with status='{row.status}'. "
+                   f"Only 'pending' or 'rejected' playbooks can be approved.",
+        )
+
+    try:
+        row.status = "approved"
+        row.reviewed_by = body.reviewed_by
+        row.reviewed_at = datetime.now(tz=timezone.utc)
+        db.commit()
+        db.refresh(row)
+        logger.info(
+            "Playbook id=%d approved by %s", playbook_id, body.reviewed_by
+        )
+    except Exception as exc:
+        db.rollback()
+        logger.error("Failed to approve playbook id=%d: %s", playbook_id, exc)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to approve playbook: {str(exc)}",
+        )
+
+    return {
+        "status": "success",
+        "message": f"Playbook {row.playbook_id} approved by {body.reviewed_by}",
+        "playbook": _serialize_playbook_detail(row),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 7. PATCH /api/sentinel/playbooks/{id}/reject — Reject a playbook
+# ---------------------------------------------------------------------------
+
+@router.patch("/playbooks/{playbook_id}/reject", response_model=Dict[str, Any])
+def reject_playbook(
+    playbook_id: int = Path(..., ge=1, description="Database ID of the playbook to reject"),
+    body: ReviewRequest = ...,
+    db: Session = Depends(get_db),
+):
+    """
+    Reject a Sentinel playbook.
+
+    Updates **three** fields atomically:
+      - ``status`` → ``"rejected"``
+      - ``reviewed_by`` → analyst username from request body
+      - ``reviewed_at`` → current UTC timestamp
+
+    Only playbooks with status ``"pending"`` can be rejected.
+    """
+    row = db.query(SentinelPlaybook).filter(SentinelPlaybook.id == playbook_id).first()
+    if not row:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Playbook with id={playbook_id} not found",
+        )
+
+    if row.status not in ("pending", "approved"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot reject playbook with status='{row.status}'. "
+                   f"Only 'pending' or 'approved' playbooks can be rejected.",
+        )
+
+    try:
+        row.status = "rejected"
+        row.reviewed_by = body.reviewed_by
+        row.reviewed_at = datetime.now(tz=timezone.utc)
+        db.commit()
+        db.refresh(row)
+        logger.info(
+            "Playbook id=%d rejected by %s", playbook_id, body.reviewed_by
+        )
+    except Exception as exc:
+        db.rollback()
+        logger.error("Failed to reject playbook id=%d: %s", playbook_id, exc)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to reject playbook: {str(exc)}",
+        )
+
+    return {
+        "status": "success",
+        "message": f"Playbook {row.playbook_id} rejected by {body.reviewed_by}",
+        "playbook": _serialize_playbook_detail(row),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 8. POST /api/sentinel/playbooks/{id}/export — Export playbook as file
+# ---------------------------------------------------------------------------
+
+_VALID_EXPORT_FORMATS = {"markdown", "json", "stix"}
+
+
+@router.post("/playbooks/{playbook_id}/export", response_class=StreamingResponse)
+def export_playbook(
+    playbook_id: int = Path(..., ge=1, description="Database ID of the playbook to export"),
+    format: str = Query(
+        default="markdown",
+        description="Export format: markdown | json | stix",
+    ),
+    db: Session = Depends(get_db),
+):
+    """
+    Export a Sentinel playbook as a downloadable file.
+
+    Supported formats via ``?format=`` query parameter:
+      - **markdown** — Playbook content as ``.md`` file (default)
+      - **json** — Full playbook record as ``.json`` file
+      - **stix** — STIX 2.1 bundle as ``.json`` file (generated on-the-fly)
+
+    On successful export, the playbook status is updated to ``"exported"``.
+    """
+    fmt = format.strip().lower()
+    if fmt not in _VALID_EXPORT_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid export format '{format}'. "
+                   f"Supported formats: {', '.join(sorted(_VALID_EXPORT_FORMATS))}",
+        )
+
+    row = db.query(SentinelPlaybook).filter(SentinelPlaybook.id == playbook_id).first()
+    if not row:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Playbook with id={playbook_id} not found",
+        )
+
+    safe_name = (row.playbook_id or f"playbook-{playbook_id}").replace(" ", "_")
+
+    # ── Build export content based on format ──────────────────────────────
+    if fmt == "markdown":
+        content = row.playbook_content or f"# {row.playbook_name}\n\nNo content available."
+        media_type = "text/markdown; charset=utf-8"
+        filename = f"{safe_name}.md"
+
+    elif fmt == "json":
+        export_data = _serialize_playbook_detail(row)
+        export_data["exported_at"] = datetime.now(tz=timezone.utc).isoformat()
+        content = json.dumps(export_data, indent=2, default=str)
+        media_type = "application/json; charset=utf-8"
+        filename = f"{safe_name}.json"
+
+    elif fmt == "stix":
+        # Build a STIX 2.1 bundle on-the-fly from the playbook's technique data
+        try:
+            from sentinel.stix_enhanced import build_stix_bundle, bundle_to_json
+
+            technique = {
+                "technique_id": row.technique_id or "T1046",
+                "technique_name": row.technique_name or "Network Service Discovery",
+                "tactic": row.tactic or "Discovery",
+                "url": row.mitre_url or "",
+                "severity": "HIGH" if (row.threat_score or 0) >= 70 else "MEDIUM",
+            }
+            iocs = [{"type": "ip", "value": row.src_ip}] if row.src_ip else []
+            tlp = "amber" if (row.threat_score or 0) >= 70 else "green"
+            bundle = build_stix_bundle(
+                technique=technique,
+                iocs=iocs,
+                src_ip=row.src_ip,
+                threat_score=row.threat_score or 0.0,
+                tlp_level=tlp,
+            )
+            content = bundle_to_json(bundle, pretty=True)
+        except Exception as exc:
+            logger.warning("STIX bundle generation failed for export: %s", exc)
+            # Fallback: export the JSON representation
+            export_data = _serialize_playbook_detail(row)
+            export_data["exported_at"] = datetime.now(tz=timezone.utc).isoformat()
+            export_data["stix_error"] = str(exc)
+            content = json.dumps(export_data, indent=2, default=str)
+
+        media_type = "application/json; charset=utf-8"
+        filename = f"{safe_name}_stix.json"
+
+    # ── Update status to exported ─────────────────────────────────────────
+    try:
+        row.status = "exported"
+        row.updated_at = datetime.now(tz=timezone.utc)
+        db.commit()
+    except Exception as exc:
+        db.rollback()
+        logger.warning("Failed to update export status for id=%d: %s", playbook_id, exc)
+
+    # ── Return file download ──────────────────────────────────────────────
+    buffer = io.BytesIO(content.encode("utf-8"))
+    buffer.seek(0)
+
+    return StreamingResponse(
+        content=buffer,
+        media_type=media_type,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "X-Playbook-Id": row.playbook_id or "",
+            "X-Export-Format": fmt,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. GET /api/sentinel/rules/snort — List all Snort rules
+# ---------------------------------------------------------------------------
+
+@router.get("/rules/snort", response_model=Dict[str, Any])
+def list_snort_rules(
+    limit: int = Query(default=50, ge=1, le=200, description="Max results per page"),
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    attack_type: Optional[str] = Query(default=None, description="Filter by attack type"),
+    db: Session = Depends(get_db),
+):
+    """
+    List all Snort IDS rules generated by the Sentinel pipeline.
+
+    Returns playbooks that have a non-null ``snort_rule`` field, with
+    pagination and optional attack_type filtering.
+    """
+    try:
+        query = db.query(SentinelPlaybook).filter(
+            SentinelPlaybook.snort_rule.isnot(None),
+            SentinelPlaybook.snort_rule != "",
+        )
+
+        if attack_type is not None and attack_type.strip():
+            query = query.filter(SentinelPlaybook.attack_type == attack_type.strip())
+
+        total = query.count()
+        rows = (
+            query
+            .order_by(SentinelPlaybook.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+        rules = []
+        for row in rows:
+            rules.append({
+                "id": row.id,
+                "playbook_id": row.playbook_id,
+                "attack_type": row.attack_type,
+                "technique_id": row.technique_id,
+                "technique_name": row.technique_name,
+                "src_ip": row.src_ip,
+                "dst_port": row.dst_port,
+                "threat_score": row.threat_score,
+                "snort_rule": row.snort_rule,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            })
+
+        return {
+            "status": "success",
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "rules": rules,
+        }
+    except Exception as exc:
+        logger.error("Failed to list Snort rules: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Failed to query Snort rules: {str(exc)}")
+
+
+# ---------------------------------------------------------------------------
+# 10. GET /api/sentinel/rules/sigma — List all Sigma rules
+# ---------------------------------------------------------------------------
+
+@router.get("/rules/sigma", response_model=Dict[str, Any])
+def list_sigma_rules(
+    limit: int = Query(default=50, ge=1, le=200, description="Max results per page"),
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    attack_type: Optional[str] = Query(default=None, description="Filter by attack type"),
+    db: Session = Depends(get_db),
+):
+    """
+    List all Sigma detection rules generated by the Sentinel pipeline.
+
+    Returns playbooks that have a non-null ``sigma_rule`` field, with
+    pagination and optional attack_type filtering.
+    """
+    try:
+        query = db.query(SentinelPlaybook).filter(
+            SentinelPlaybook.sigma_rule.isnot(None),
+            SentinelPlaybook.sigma_rule != "",
+        )
+
+        if attack_type is not None and attack_type.strip():
+            query = query.filter(SentinelPlaybook.attack_type == attack_type.strip())
+
+        total = query.count()
+        rows = (
+            query
+            .order_by(SentinelPlaybook.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+        rules = []
+        for row in rows:
+            rules.append({
+                "id": row.id,
+                "playbook_id": row.playbook_id,
+                "attack_type": row.attack_type,
+                "technique_id": row.technique_id,
+                "technique_name": row.technique_name,
+                "src_ip": row.src_ip,
+                "dst_port": row.dst_port,
+                "threat_score": row.threat_score,
+                "sigma_rule": row.sigma_rule,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            })
+
+        return {
+            "status": "success",
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "rules": rules,
+        }
+    except Exception as exc:
+        logger.error("Failed to list Sigma rules: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Failed to query Sigma rules: {str(exc)}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -282,7 +282,7 @@ app.add_middleware(
         "http://127.0.0.1:5173",
     ],
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     allow_headers=["*"],
 )
 

--- a/tests/verify_sentinel_api.py
+++ b/tests/verify_sentinel_api.py
@@ -1,17 +1,29 @@
 """
-Verify Sentinel API — Week 14 Day 2 — 10-point test suite.
+Verify Sentinel API — Week 14 Day 2 + Day 3 — 20-point test suite.
 
-Tests:
+Tests (Day 2 — existing 5 endpoints):
   1. Router module imports correctly
   2. Router has correct prefix and tags
-  3. All 5 route paths registered
+  3. All 10 route paths registered
   4. GET /playbooks returns paginated list
   5. GET /playbooks/{id} returns 404 for missing
   6. GET /stats returns correct structure
   7. GET /mitre/mapping returns all 12 techniques
   8. POST /generate creates a playbook
-  9. Router registered in main.py import
+  9. Router imported in main.py
  10. Router included in main.py app
+
+Tests (Day 3 — new 5 endpoints):
+ 11. PATCH /playbooks/{id}/approve updates three fields
+ 12. PATCH /playbooks/{id}/approve returns 404 for missing
+ 13. PATCH /playbooks/{id}/reject updates three fields
+ 14. PATCH /playbooks/{id}/reject returns 404 for missing
+ 15. POST /playbooks/{id}/export with format=markdown
+ 16. POST /playbooks/{id}/export with format=json
+ 17. POST /playbooks/{id}/export with invalid format returns 400
+ 18. GET /rules/snort returns paginated list
+ 19. GET /rules/sigma returns paginated list
+ 20. Input validation rejects empty reviewed_by
 """
 import sys
 sys.path.insert(0, "backend")
@@ -25,8 +37,14 @@ Base.metadata.create_all(bind=engine)
 # ------------------------------------------------------------------
 # Test 1: Module imports
 # ------------------------------------------------------------------
-from api.sentinel import router, list_playbooks, get_playbook, get_sentinel_stats, get_mitre_mappings, generate_playbook
-print("Test 1  PASS: api.sentinel module imports correctly")
+from api.sentinel import (
+    router, list_playbooks, get_playbook, get_sentinel_stats,
+    get_mitre_mappings, generate_playbook,
+    approve_playbook, reject_playbook, export_playbook,
+    list_snort_rules, list_sigma_rules,
+    ReviewRequest,
+)
+print("Test 1  PASS: api.sentinel module imports correctly (all 10 endpoints + ReviewRequest)")
 
 # ------------------------------------------------------------------
 # Test 2: Router prefix & tags
@@ -36,7 +54,7 @@ assert "Sentinel" in router.tags, f"Expected 'Sentinel' in tags, got {router.tag
 print("Test 2  PASS: Router prefix=/api/sentinel, tags=['Sentinel']")
 
 # ------------------------------------------------------------------
-# Test 3: All 5 route paths registered
+# Test 3: All 10 route paths registered
 # ------------------------------------------------------------------
 route_paths = [r.path for r in router.routes]
 expected_paths = [
@@ -45,10 +63,15 @@ expected_paths = [
     "/api/sentinel/stats",
     "/api/sentinel/mitre/mapping",
     "/api/sentinel/generate",
+    "/api/sentinel/playbooks/{playbook_id}/approve",
+    "/api/sentinel/playbooks/{playbook_id}/reject",
+    "/api/sentinel/playbooks/{playbook_id}/export",
+    "/api/sentinel/rules/snort",
+    "/api/sentinel/rules/sigma",
 ]
 for ep in expected_paths:
     assert ep in route_paths, f"Missing route: {ep}"
-print(f"Test 3  PASS: All 5 routes registered: {expected_paths}")
+print(f"Test 3  PASS: All 10 routes registered")
 
 # ------------------------------------------------------------------
 # Test 4: GET /playbooks works (via direct function call)
@@ -124,13 +147,8 @@ assert gen_result["service_type"] == "SSH"
 assert gen_result["attack_type"] == "SSH_AUTH_FAILURE"
 assert gen_result["db_record_id"] > 0
 pb_id = gen_result["playbook_id"]
+test_db_id = gen_result["db_record_id"]
 print(f"Test 8  PASS: POST /generate creates playbook (id={pb_id})")
-
-# Cleanup generated playbook
-row = db.query(_SP).filter_by(playbook_id=pb_id).first()
-if row:
-    db.delete(row)
-    db.commit()
 
 # ------------------------------------------------------------------
 # Test 9: Router imported in main.py
@@ -146,9 +164,149 @@ print("Test 9  PASS: Router imported in main.py")
 assert "app.include_router(sentinel_router)" in main_source
 print("Test 10 PASS: Router included in main.py app")
 
+# ==================================================================
+# Day 3 Tests — New 5 endpoints
+# ==================================================================
+
+# ------------------------------------------------------------------
+# Test 11: PATCH /playbooks/{id}/approve updates three fields
+# ------------------------------------------------------------------
+review_req = ReviewRequest(reviewed_by="analyst_tester")
+approve_result = approve_playbook(playbook_id=test_db_id, body=review_req, db=db)
+assert approve_result["status"] == "success"
+assert "approved" in approve_result["message"]
+assert approve_result["playbook"]["status"] == "approved"
+assert approve_result["playbook"]["reviewed_by"] == "analyst_tester"
+assert approve_result["playbook"]["reviewed_at"] is not None
+print(f"Test 11 PASS: PATCH /approve updates status, reviewed_by, reviewed_at")
+
+# ------------------------------------------------------------------
+# Test 12: PATCH /playbooks/{id}/approve returns 404 for missing
+# ------------------------------------------------------------------
+try:
+    approve_playbook(playbook_id=999999, body=review_req, db=db)
+    assert False, "Should have raised HTTPException"
+except HTTPException as exc:
+    assert exc.status_code == 404
+    print("Test 12 PASS: PATCH /approve returns 404 for missing playbook")
+
+# ------------------------------------------------------------------
+# Test 13: PATCH /playbooks/{id}/reject updates three fields
+# ------------------------------------------------------------------
+reject_req = ReviewRequest(reviewed_by="senior_analyst")
+reject_result = reject_playbook(playbook_id=test_db_id, body=reject_req, db=db)
+assert reject_result["status"] == "success"
+assert "rejected" in reject_result["message"]
+assert reject_result["playbook"]["status"] == "rejected"
+assert reject_result["playbook"]["reviewed_by"] == "senior_analyst"
+assert reject_result["playbook"]["reviewed_at"] is not None
+print(f"Test 13 PASS: PATCH /reject updates status, reviewed_by, reviewed_at")
+
+# ------------------------------------------------------------------
+# Test 14: PATCH /playbooks/{id}/reject returns 404 for missing
+# ------------------------------------------------------------------
+try:
+    reject_playbook(playbook_id=999999, body=reject_req, db=db)
+    assert False, "Should have raised HTTPException"
+except HTTPException as exc:
+    assert exc.status_code == 404
+    print("Test 14 PASS: PATCH /reject returns 404 for missing playbook")
+
+# ------------------------------------------------------------------
+# Test 15: POST /playbooks/{id}/export with format=markdown
+# ------------------------------------------------------------------
+# Re-approve so we can export
+approve_playbook(playbook_id=test_db_id, body=ReviewRequest(reviewed_by="exporter"), db=db)
+
+export_md = export_playbook(playbook_id=test_db_id, format="markdown", db=db)
+assert export_md.status_code == 200
+assert "text/markdown" in export_md.media_type
+assert export_md.headers.get("content-disposition") is not None
+assert ".md" in export_md.headers.get("content-disposition", "")
+print("Test 15 PASS: POST /export format=markdown returns .md file download")
+
+# ------------------------------------------------------------------
+# Test 16: POST /playbooks/{id}/export with format=json
+# ------------------------------------------------------------------
+# Reset status to test export again
+row = db.query(_SP).filter(_SP.id == test_db_id).first()
+row.status = "approved"
+db.commit()
+
+export_json = export_playbook(playbook_id=test_db_id, format="json", db=db)
+assert export_json.status_code == 200
+assert "application/json" in export_json.media_type
+assert ".json" in export_json.headers.get("content-disposition", "")
+print("Test 16 PASS: POST /export format=json returns .json file download")
+
+# ------------------------------------------------------------------
+# Test 17: POST /playbooks/{id}/export with invalid format returns 400
+# ------------------------------------------------------------------
+try:
+    export_playbook(playbook_id=test_db_id, format="invalid_format", db=db)
+    assert False, "Should have raised HTTPException for invalid format"
+except HTTPException as exc:
+    assert exc.status_code == 400
+    assert "Invalid export format" in str(exc.detail)
+    print("Test 17 PASS: POST /export with invalid format returns 400")
+
+# ------------------------------------------------------------------
+# Test 18: GET /rules/snort returns paginated list
+# ------------------------------------------------------------------
+snort_result = list_snort_rules(limit=10, offset=0, attack_type=None, db=db)
+assert snort_result["status"] == "success"
+assert "total" in snort_result
+assert "rules" in snort_result
+assert isinstance(snort_result["rules"], list)
+assert "limit" in snort_result
+assert "offset" in snort_result
+# Verify rule structure if rules exist
+if snort_result["rules"]:
+    rule = snort_result["rules"][0]
+    assert "snort_rule" in rule
+    assert "playbook_id" in rule
+    assert "attack_type" in rule
+print(f"Test 18 PASS: GET /rules/snort returns paginated list (total={snort_result['total']})")
+
+# ------------------------------------------------------------------
+# Test 19: GET /rules/sigma returns paginated list
+# ------------------------------------------------------------------
+sigma_result = list_sigma_rules(limit=10, offset=0, attack_type=None, db=db)
+assert sigma_result["status"] == "success"
+assert "total" in sigma_result
+assert "rules" in sigma_result
+assert isinstance(sigma_result["rules"], list)
+assert "limit" in sigma_result
+assert "offset" in sigma_result
+# Verify rule structure if rules exist
+if sigma_result["rules"]:
+    rule = sigma_result["rules"][0]
+    assert "sigma_rule" in rule
+    assert "playbook_id" in rule
+    assert "attack_type" in rule
+print(f"Test 19 PASS: GET /rules/sigma returns paginated list (total={sigma_result['total']})")
+
+# ------------------------------------------------------------------
+# Test 20: Input validation rejects empty reviewed_by
+# ------------------------------------------------------------------
+from pydantic import ValidationError
+try:
+    ReviewRequest(reviewed_by="")
+    assert False, "Should have raised ValidationError for empty reviewed_by"
+except ValidationError:
+    print("Test 20 PASS: Input validation rejects empty reviewed_by")
+
+# ------------------------------------------------------------------
+# Cleanup: Remove test playbook
+# ------------------------------------------------------------------
+cleanup_row = db.query(_SP).filter_by(playbook_id=pb_id).first()
+if cleanup_row:
+    db.delete(cleanup_row)
+    db.commit()
+
 db.close()
 
 print()
-print("=" * 55)
-print("ALL 10 TESTS PASSED — Sentinel API W14D2 verified!")
-print("=" * 55)
+print("=" * 60)
+print("ALL 20 TESTS PASSED — Sentinel API W14 Day 2+3 verified!")
+print("=" * 60)


### PR DESCRIPTION
…ort rules, sigma rules [W14D3]

- PATCH /api/sentinel/playbooks/{id}/approve — sets status, reviewed_by, reviewed_at
- PATCH /api/sentinel/playbooks/{id}/reject — sets status, reviewed_by, reviewed_at
- POST /api/sentinel/playbooks/{id}/export — file download (?format=markdown|json|stix)
- GET /api/sentinel/rules/snort — paginated Snort rule listing
- GET /api/sentinel/rules/sigma — paginated Sigma rule listing
- Add ReviewRequest schema with input validation (min/max length, whitespace rejection)
- Add PATCH to CORS allow_methods in main.py
- Expand test suite from 10 to 20 tests — all passing
- Error handling: 404 invalid IDs, 400 invalid format, 409 invalid status transitions

Sentinel API now complete with all 10 endpoints.
#PhantomNet #Week14 #Day3