### PR TITLE
Week 18-Day 4: Add added_after filtering to TAXII objects endpoint (#…

### DIFF
--- a/backend/api/taxii.py
+++ b/backend/api/taxii.py
@@ -10,22 +10,27 @@ Provides TAXII 2.1 protocol compliant endpoints:
   GET /taxii2/phantomnet/collections/{collection_id}/   — Specific Collection Detail
   GET /taxii2/phantomnet/collections/{collection_id}/objects/ — STIX Objects Retrieval
 
+Query Parameter Filtering:
+  - ?added_after=<ISO 8601 timestamp>  — Filter objects by creation date (strict >)
+
 Spec Compliance:
   - Enforces OASIS TAXII 2.1 media type negotiation (Content-Type: application/taxii+json;version=2.1 and application/stix+json;version=2.1)
   - Rejects unsupported explicit Accept headers with 406 Not Acceptable
   - Queries SQLite database for dynamic collection mappings (tactics, honeypot sources) and builds STIX 2.1 bundles.
 
 Week 18, Day 1 & Day 2 — TAXII Server Architecture & Collections Endpoint
+Week 18, Day 4 — Add Filtering to TAXII Objects Endpoint (added_after)
 """
 
 from __future__ import annotations
 
 import logging
+import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Path, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, Response
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
@@ -437,7 +442,74 @@ def get_collection_detail(
 
 
 # ---------------------------------------------------------------------------
-# 5. GET /taxii2/phantomnet/collections/{id}/objects/ — Collection Objects Endpoint
+# 5. Timestamp Parsing Helper for added_after Filtering
+# ---------------------------------------------------------------------------
+
+def parse_added_after(
+    added_after: Optional[str],
+) -> tuple[Optional[datetime], Optional[JSONResponse]]:
+    """
+    Parse and validate an ISO 8601 / RFC 3339 timestamp string from the
+    ``added_after`` query parameter.
+
+    Supports formats:
+      - Full datetime with Z suffix:     2026-07-01T00:00:00Z
+      - Full datetime with offset:       2026-07-01T00:00:00+05:30
+      - Full datetime without timezone:  2026-07-01T00:00:00 (treated as UTC)
+      - Date only:                       2026-07-01 (treated as midnight UTC)
+      - Microsecond precision:           2026-07-01T12:30:00.123456Z
+
+    Args:
+        added_after: Raw query parameter value, may be None or empty string.
+
+    Returns:
+        Tuple of (parsed_datetime, error_response).
+        On success: (datetime, None)  — datetime is always UTC-aware.
+        On skip:    (None, None)      — parameter was absent or empty.
+        On error:   (None, JSONResponse) — 400 response with TAXII error body.
+    """
+    if not added_after or not added_after.strip():
+        return None, None
+
+    raw = added_after.strip()
+
+    try:
+        # Replace trailing 'Z' with '+00:00' for fromisoformat compatibility
+        normalized = raw
+        if normalized.upper().endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+
+        dt = datetime.fromisoformat(normalized)
+
+        # If the parsed datetime is naive (no timezone info), assume UTC
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+
+        # Normalize to UTC for consistent DB comparison
+        dt = dt.astimezone(timezone.utc)
+
+        return dt, None
+
+    except (ValueError, TypeError) as exc:
+        logger.warning("Invalid added_after timestamp '%s': %s", raw, exc)
+        err = TaxiiErrorResponse(
+            title="Invalid Timestamp",
+            description=(
+                f"The 'added_after' parameter value '{raw}' is not a valid "
+                f"ISO 8601 / RFC 3339 timestamp. "
+                f"Expected format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS±HH:MM"
+            ),
+            http_status="400",
+        )
+        return None, JSONResponse(
+            content=err.model_dump(),
+            status_code=400,
+            headers={"Content-Type": TAXII_MEDIA_TYPE},
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. GET /taxii2/phantomnet/collections/{id}/objects/ — Collection Objects Endpoint
 # ---------------------------------------------------------------------------
 
 @router.get(
@@ -451,6 +523,14 @@ def get_collection_detail(
 )
 def get_collection_objects(
     id: str = Path(..., description="The ID or alias of the collection"),
+    added_after: Optional[str] = Query(
+        None,
+        description=(
+            "ISO 8601 / RFC 3339 timestamp. Only objects with a created_at "
+            "date strictly after this value will be returned. "
+            "Example: 2026-07-01T00:00:00Z"
+        ),
+    ),
     db: Session = Depends(get_db),
     accept: Optional[str] = Header(None),
     content_type: Optional[str] = Header(None),
@@ -477,9 +557,21 @@ def get_collection_objects(
         (c for c in cols if c.id == id or c.alias == id), None
     )
 
+    # Parse and validate added_after filter parameter
+    added_after_dt, added_after_err = parse_added_after(added_after)
+    if added_after_err:
+        return added_after_err
+
     # Fetch playbooks from DB
     try:
         query = db.query(SentinelPlaybook)
+
+        # Apply added_after timestamp filter (strict greater-than per TAXII 2.1 §5.4)
+        if added_after_dt is not None:
+            # Strip timezone info for comparison with naive DB timestamps
+            filter_dt = added_after_dt.replace(tzinfo=None)
+            query = query.filter(SentinelPlaybook.created_at > filter_dt)
+
         if matched_col and matched_col.id.startswith("tactic-"):
             tactic_slug = matched_col.id.replace("tactic-", "")
             playbooks = [

--- a/backend/tests/test_taxii.py
+++ b/backend/tests/test_taxii.py
@@ -217,6 +217,129 @@ def test_taxii_collection_objects(client):
     assert isinstance(data["objects"], list)
 
 
+# ---------------------------------------------------------------------------
+# Week 18-Day 4: added_after Query Parameter Filtering Tests
+# ---------------------------------------------------------------------------
+
+
+def test_objects_added_after_filters_correctly(client):
+    """Verify added_after correctly filters playbooks — only newer ones returned."""
+    db = SessionLocal()
+    try:
+        old_pb = SentinelPlaybook(
+            playbook_id="PB-TEST-FILTER-OLD",
+            status="approved",
+            tactic="Initial Access",
+            src_ip="10.0.0.1",
+            dst_port=22,
+            created_at=datetime(2025, 1, 1, 0, 0, 0),
+            updated_at=datetime(2025, 1, 1, 0, 0, 0),
+        )
+        new_pb = SentinelPlaybook(
+            playbook_id="PB-TEST-FILTER-NEW",
+            status="approved",
+            tactic="Initial Access",
+            src_ip="10.0.0.2",
+            dst_port=22,
+            created_at=datetime(2026, 6, 15, 12, 0, 0),
+            updated_at=datetime(2026, 6, 15, 12, 0, 0),
+        )
+        db.add_all([old_pb, new_pb])
+        db.commit()
+
+        # Query with added_after between the two — only new_pb should appear
+        res = client.get(
+            "/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/",
+            params={"added_after": "2026-01-01T00:00:00Z"},
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "bundle"
+
+        # The new playbook's report object should be present
+        report_names = [
+            obj.get("name", "") for obj in data["objects"] if obj.get("type") == "report"
+        ]
+        has_new = any("PB-TEST-FILTER-NEW" in name for name in report_names)
+        has_old = any("PB-TEST-FILTER-OLD" in name for name in report_names)
+        assert has_new, "Expected new playbook to be present after filtering"
+        assert not has_old, "Expected old playbook to be excluded by added_after filter"
+
+    finally:
+        db.query(SentinelPlaybook).filter(
+            SentinelPlaybook.playbook_id.in_(["PB-TEST-FILTER-OLD", "PB-TEST-FILTER-NEW"])
+        ).delete(synchronize_session=False)
+        db.commit()
+        db.close()
+
+
+def test_objects_added_after_no_param(client):
+    """Verify no added_after parameter returns all objects (backward compatibility)."""
+    res = client.get("/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["type"] == "bundle"
+    assert "objects" in data
+
+
+def test_objects_added_after_empty_string(client):
+    """Verify empty added_after parameter is treated as no filter."""
+    res = client.get(
+        "/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/",
+        params={"added_after": ""},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["type"] == "bundle"
+
+
+def test_objects_added_after_invalid_format(client):
+    """Verify invalid added_after timestamp returns 400 with TAXII error body."""
+    res = client.get(
+        "/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/",
+        params={"added_after": "not-a-date"},
+    )
+    assert res.status_code == 400
+    data = res.json()
+    assert data["title"] == "Invalid Timestamp"
+    assert data["http_status"] == "400"
+    assert "not-a-date" in data.get("description", "")
+
+
+def test_objects_added_after_with_timezone(client):
+    """Verify added_after with timezone offset is correctly parsed."""
+    res = client.get(
+        "/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/",
+        params={"added_after": "2026-01-01T00:00:00+05:30"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["type"] == "bundle"
+
+
+def test_objects_added_after_date_only(client):
+    """Verify added_after with date-only format is treated as midnight UTC."""
+    res = client.get(
+        "/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/",
+        params={"added_after": "2026-01-01"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["type"] == "bundle"
+
+
+def test_objects_added_after_future_date(client):
+    """Verify added_after with future timestamp returns empty bundle."""
+    res = client.get(
+        "/taxii2/phantomnet/collections/sentinel-playbooks-approved/objects/",
+        params={"added_after": "2099-12-31T23:59:59Z"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["type"] == "bundle"
+    assert len(data["objects"]) == 0
+
+
 if __name__ == "__main__":
     test_client = TestClient(app)
     print("Running test_taxii_discovery...")
@@ -247,4 +370,18 @@ if __name__ == "__main__":
     test_taxii_wildcard_accept_header(test_client)
     print("Running test_taxii_collection_objects...")
     test_taxii_collection_objects(test_client)
-    print("\nSUCCESS: All 14 TAXII 2.1 Server tests passed successfully!")
+    print("Running test_objects_added_after_filters_correctly...")
+    test_objects_added_after_filters_correctly(test_client)
+    print("Running test_objects_added_after_no_param...")
+    test_objects_added_after_no_param(test_client)
+    print("Running test_objects_added_after_empty_string...")
+    test_objects_added_after_empty_string(test_client)
+    print("Running test_objects_added_after_invalid_format...")
+    test_objects_added_after_invalid_format(test_client)
+    print("Running test_objects_added_after_with_timezone...")
+    test_objects_added_after_with_timezone(test_client)
+    print("Running test_objects_added_after_date_only...")
+    test_objects_added_after_date_only(test_client)
+    print("Running test_objects_added_after_future_date...")
+    test_objects_added_after_future_date(test_client)
+    print("\nSUCCESS: All 21 TAXII 2.1 Server tests passed successfully!")


### PR DESCRIPTION
…874)

- Add parse_added_after() helper with robust ISO 8601/RFC 3339 parsing
- Support Z suffix, timezone offsets, date-only, and microsecond formats
- Apply strict greater-than filter on SentinelPlaybook.created_at per TAXII 2.1 spec
- Return TAXII 400 error with descriptive body for invalid timestamps
- Add 7 new test cases covering filtering, edge cases, and error handling
- All 21 TAXII tests passing