### PR TITLE
feat: Sentinel Auto-Generation Background Scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,12 @@ PYTHONIOENCODING=utf-8
 # Set to true to enable automatic playbook generation from campaign clustering
 SENTINEL_ENABLED=false
 
+# Sentinel Auto-Generation Scheduler (APScheduler-based, opt-in)
+# Set to true to enable periodic background playbook auto-generation
+SENTINEL_AUTO_GEN_ENABLED=false
+# Interval in minutes between auto-generation cycles (minimum: 1)
+SENTINEL_AUTO_GEN_INTERVAL_MINUTES=30
+
 # Sentinel LLM Configuration (opt-in)
 # Set to true to enable AI-enhanced narratives inside incident playbooks
 SENTINEL_LLM_ENABLED=false

--- a/backend/config/sentinel_config.py
+++ b/backend/config/sentinel_config.py
@@ -1,0 +1,101 @@
+"""
+backend/config/sentinel_config.py
+-----------------------------------
+Sentinel Layer — Configuration Module
+
+Centralises all Sentinel-specific configuration flags read from
+environment variables.  Each setting has a sensible default so the
+system works out-of-the-box without any `.env` changes.
+
+Environment Variables
+---------------------
+  SENTINEL_ENABLED                    : Master switch for the legacy async
+                                        generation loop in main.py.
+  SENTINEL_AUTO_GEN_ENABLED           : Enable/disable APScheduler-based
+                                        periodic playbook auto-generation.
+  SENTINEL_AUTO_GEN_INTERVAL_MINUTES  : Interval in minutes between
+                                        successive auto-generation runs.
+  SENTINEL_LLM_ENABLED                : Enable AI-enhanced narrative
+                                        summaries inside playbooks.
+  SENTINEL_LLM_HOST                   : Ollama inference server URL.
+  SENTINEL_LLM_MODEL                  : LLM model name pulled in Ollama.
+
+Phase 5, Week 4 — Sentinel Auto-Generation Scheduler
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+
+logger = logging.getLogger("sentinel.config")
+
+
+def _env_bool(key: str, default: bool = False) -> bool:
+    """Read a boolean environment variable (true/false, 1/0, yes/no)."""
+    val = os.getenv(key, "").strip().lower()
+    if not val:
+        return default
+    return val in ("true", "1", "yes", "on")
+
+
+def _env_int(key: str, default: int = 0) -> int:
+    """Read an integer environment variable with a safe fallback."""
+    val = os.getenv(key, "").strip()
+    if not val:
+        return default
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        logger.warning(
+            "Invalid integer for %s=%r — using default %d", key, val, default
+        )
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Sentinel Auto-Generation Scheduler Configuration
+# ---------------------------------------------------------------------------
+
+SENTINEL_AUTO_GEN_ENABLED: bool = _env_bool("SENTINEL_AUTO_GEN_ENABLED", default=False)
+"""
+When True, the SchedulerService will register an APScheduler interval job
+that periodically triggers the Sentinel pipeline to scan for new campaign
+clusters and auto-generate playbooks.
+
+Default: False (opt-in via environment variable).
+"""
+
+SENTINEL_AUTO_GEN_INTERVAL_MINUTES: int = _env_int(
+    "SENTINEL_AUTO_GEN_INTERVAL_MINUTES", default=30
+)
+"""
+Interval (in minutes) between successive sentinel auto-generation runs.
+Must be >= 1 minute; values below 1 are clamped to 1 to avoid CPU thrashing.
+
+Default: 30 minutes.
+"""
+# Clamp to minimum of 1 minute
+if SENTINEL_AUTO_GEN_INTERVAL_MINUTES < 1:
+    logger.warning(
+        "SENTINEL_AUTO_GEN_INTERVAL_MINUTES=%d is too low — clamping to 1",
+        SENTINEL_AUTO_GEN_INTERVAL_MINUTES,
+    )
+    SENTINEL_AUTO_GEN_INTERVAL_MINUTES = 1
+
+
+# ---------------------------------------------------------------------------
+# General Sentinel Flags (re-exposed for central access)
+# ---------------------------------------------------------------------------
+
+SENTINEL_ENABLED: bool = _env_bool("SENTINEL_ENABLED", default=False)
+"""Master switch for the legacy async sentinel generation loop in main.py."""
+
+SENTINEL_LLM_ENABLED: bool = _env_bool("SENTINEL_LLM_ENABLED", default=False)
+"""Enable AI-enhanced narrative summaries inside incident playbooks."""
+
+SENTINEL_LLM_HOST: str = os.getenv("SENTINEL_LLM_HOST", "http://ollama:11434")
+"""Ollama inference server base URL."""
+
+SENTINEL_LLM_MODEL: str = os.getenv("SENTINEL_LLM_MODEL", "mistral")
+"""LLM model name pulled inside Ollama."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -140,6 +140,13 @@ async def lifespan(_app: FastAPI):
         scheduler_service.load_schedules()
         print("Scheduled Reports Loader Started")
 
+        # Start Sentinel Auto-Generation Scheduler (APScheduler-based, opt-in)
+        _auto_gen_started = scheduler_service.start_sentinel_auto_gen()
+        if _auto_gen_started:
+            print("[OK] Sentinel Auto-Gen Scheduler started (APScheduler interval job)")
+        else:
+            print("[--] Sentinel Auto-Gen Scheduler disabled (SENTINEL_AUTO_GEN_ENABLED=false)")
+
         # Start Real-Time Metrics Broadcaster
         asyncio.create_task(broadcast_live_metrics())
         # Start PCAP Retention Cleanup (daily)
@@ -165,6 +172,7 @@ async def lifespan(_app: FastAPI):
 
     yield
     print("PhantomNet Shutting Down")
+    scheduler_service.stop_sentinel_auto_gen()
     threat_analyzer.stop()
 
 

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -1,26 +1,82 @@
+"""
+backend/services/scheduler_service.py
+--------------------------------------
+PhantomNet — Background Task Scheduler Service
+
+Manages two categories of scheduled work:
+
+  1. **Report Generation Jobs** (existing) — APScheduler cron-based jobs
+     that generate and deliver periodic reports.
+
+  2. **Sentinel Auto-Generation Job** (new) — An interval-based APScheduler
+     job that periodically triggers the Sentinel pipeline to scan for new
+     campaign clusters and auto-generate playbooks.
+
+Concurrency Safety
+------------------
+The sentinel auto-generation job uses a ``threading.Lock`` to guarantee
+that only one generation cycle can execute at a time.  If a previous
+cycle is still running when the next trigger fires, the new invocation
+exits immediately (non-blocking ``acquire(blocking=False)``).
+
+Configuration
+-------------
+  SENTINEL_AUTO_GEN_ENABLED          : Enable the periodic job (default: False).
+  SENTINEL_AUTO_GEN_INTERVAL_MINUTES : Interval in minutes (default: 30).
+
+Phase 5, Week 4 — Sentinel Auto-Generation Scheduler
+"""
+
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy.orm import Session
 from database.database import SessionLocal
 from database.models import ScheduledReport
 from services.report_service import ReportService
 from datetime import datetime, timedelta
+import hashlib
 import json
 import logging
+import os
+import threading
+from typing import Set
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-import os
-
-
 class SchedulerService:
+    """Central scheduler for all PhantomNet background tasks.
+
+    Attributes
+    ----------
+    scheduler : BackgroundScheduler
+        The APScheduler instance that manages all registered jobs.
+    _sentinel_lock : threading.Lock
+        Mutex ensuring at most one sentinel auto-generation cycle runs
+        concurrently.  Uses non-blocking acquisition so overlapping
+        triggers are skipped rather than queued.
+    _sentinel_processed_hashes : set[str]
+        In-memory set of deterministic campaign hashes that have already
+        been processed.  Pre-seeded from the database on first run to
+        survive process restarts.
+    _sentinel_seeded : bool
+        Whether the in-memory dedup set has been pre-seeded from the DB.
+    """
+
     def __init__(self):
         self.scheduler = BackgroundScheduler()
+        self._sentinel_lock = threading.Lock()
+        self._sentinel_processed_hashes: Set[str] = set()
+        self._sentinel_seeded = False
+
         if os.getenv("ENVIRONMENT") not in ("test", "ci"):
             self.scheduler.start()
 
+    # ------------------------------------------------------------------
+    # Report scheduling (existing functionality)
+    # ------------------------------------------------------------------
     def load_schedules(self):
         db = SessionLocal()
         try:
@@ -92,6 +148,301 @@ class SchedulerService:
             logger.error(f"Error running scheduled report {report_id}: {e}")
         finally:
             db.close()
+
+    # ==================================================================
+    # Sentinel Auto-Generation Scheduler
+    # ==================================================================
+
+    def start_sentinel_auto_gen(self) -> bool:
+        """Register the periodic sentinel playbook auto-generation job.
+
+        Reads ``SENTINEL_AUTO_GEN_ENABLED`` and
+        ``SENTINEL_AUTO_GEN_INTERVAL_MINUTES`` from environment (via
+        ``config.sentinel_config``) to decide whether and how often
+        to run.
+
+        Returns
+        -------
+        bool
+            True if the job was registered, False if auto-gen is disabled
+            or the scheduler is not running.
+        """
+        from config.sentinel_config import (
+            SENTINEL_AUTO_GEN_ENABLED,
+            SENTINEL_AUTO_GEN_INTERVAL_MINUTES,
+        )
+
+        if not SENTINEL_AUTO_GEN_ENABLED:
+            logger.info(
+                "[Sentinel AutoGen] Disabled (SENTINEL_AUTO_GEN_ENABLED=false)"
+            )
+            return False
+
+        # Prevent duplicate registration
+        existing = self.scheduler.get_job("sentinel_auto_gen")
+        if existing is not None:
+            logger.info(
+                "[Sentinel AutoGen] Job already registered — skipping re-registration"
+            )
+            return True
+
+        trigger = IntervalTrigger(minutes=SENTINEL_AUTO_GEN_INTERVAL_MINUTES)
+
+        self.scheduler.add_job(
+            self._run_sentinel_auto_gen_cycle,
+            trigger=trigger,
+            id="sentinel_auto_gen",
+            name="Sentinel Playbook Auto-Generation",
+            replace_existing=True,
+            max_instances=1,  # APScheduler-level guard
+        )
+
+        logger.info(
+            "[Sentinel AutoGen] Registered — interval=%d min",
+            SENTINEL_AUTO_GEN_INTERVAL_MINUTES,
+        )
+        return True
+
+    def stop_sentinel_auto_gen(self) -> bool:
+        """Remove the sentinel auto-generation job if it exists.
+
+        Returns
+        -------
+        bool
+            True if the job was removed, False if it was not registered.
+        """
+        existing = self.scheduler.get_job("sentinel_auto_gen")
+        if existing is None:
+            return False
+        self.scheduler.remove_job("sentinel_auto_gen")
+        logger.info("[Sentinel AutoGen] Job removed")
+        return True
+
+    # ------------------------------------------------------------------
+    # Pre-seed dedup hashes from DB (survives process restarts)
+    # ------------------------------------------------------------------
+    def _seed_sentinel_hashes(self) -> None:
+        """Pre-populate the in-memory dedup set from existing SentinelPlaybook rows.
+
+        This is called once on the first auto-gen cycle to ensure that
+        playbooks generated before a process restart are not re-generated.
+        """
+        if self._sentinel_seeded:
+            return
+
+        from sentinel.models import SentinelPlaybook
+
+        db = SessionLocal()
+        try:
+            existing = (
+                db.query(
+                    SentinelPlaybook.src_ip,
+                    SentinelPlaybook.playbook_id,
+                )
+                .all()
+            )
+            for row in existing:
+                self._sentinel_processed_hashes.add(row.playbook_id)
+
+            self._sentinel_seeded = True
+            logger.info(
+                "[Sentinel AutoGen] Pre-seeded %d existing playbook IDs for dedup",
+                len(self._sentinel_processed_hashes),
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Sentinel AutoGen] DB pre-seed failed (non-fatal): %s", exc
+            )
+        finally:
+            db.close()
+
+    # ------------------------------------------------------------------
+    # Core auto-generation cycle (lock-protected)
+    # ------------------------------------------------------------------
+    def _run_sentinel_auto_gen_cycle(self) -> None:
+        """Execute one sentinel auto-generation cycle.
+
+        Acquires ``_sentinel_lock`` in non-blocking mode:
+        - If the lock is free → runs the full cycle.
+        - If the lock is held → skips this invocation (prevents pile-up).
+
+        The cycle:
+        1. Pre-seed dedup hashes from DB (first run only).
+        2. Run campaign clustering (identify_campaigns).
+        3. For each new campaign, build a deterministic hash and check dedup.
+        4. Feed new campaigns into SentinelService.generate_playbook().
+        """
+        acquired = self._sentinel_lock.acquire(blocking=False)
+        if not acquired:
+            logger.warning(
+                "[Sentinel AutoGen] Skipping cycle — previous cycle still running "
+                "(lock held)"
+            )
+            return
+
+        try:
+            self._execute_sentinel_cycle()
+        except Exception as exc:
+            logger.error(
+                "[Sentinel AutoGen] Unhandled error in cycle: %s", exc,
+                exc_info=True,
+            )
+        finally:
+            self._sentinel_lock.release()
+
+    def _execute_sentinel_cycle(self) -> None:
+        """Internal: the actual sentinel pipeline cycle (runs under lock)."""
+        from ml_engine.campaign_clustering import campaign_clusterer
+        from sentinel.sentinel_service import SentinelService
+
+        logger.info("=" * 60)
+        logger.info("[Sentinel AutoGen] Cycle starting")
+
+        # Step 0: Pre-seed dedup set on first run
+        self._seed_sentinel_hashes()
+
+        # Step 1: Run campaign clustering
+        try:
+            result = campaign_clusterer.identify_campaigns(24)
+        except Exception as exc:
+            logger.error(
+                "[Sentinel AutoGen] Campaign clustering failed: %s", exc
+            )
+            return
+
+        if not result or result.get("campaign_count", 0) == 0:
+            logger.info("[Sentinel AutoGen] No campaigns detected — sleeping")
+            return
+
+        campaigns = result.get("campaigns", [])
+        total_found = len(campaigns)
+        new_count = 0
+        skipped_count = 0
+        error_count = 0
+
+        logger.info(
+            "[Sentinel AutoGen] %d campaign(s) found from clustering",
+            total_found,
+        )
+
+        # Step 2: Process each campaign
+        db = SessionLocal()
+        try:
+            svc = SentinelService(db)
+
+            for campaign in campaigns:
+                campaign_id = campaign.get("campaign_id", "")
+                if not campaign_id:
+                    logger.warning(
+                        "[Sentinel AutoGen] Skipping campaign with empty campaign_id"
+                    )
+                    skipped_count += 1
+                    continue
+
+                # Build deterministic dedup hash
+                source_ips = sorted(campaign.get("unique_sources", []))
+                target_ports = sorted(
+                    str(p) for p in campaign.get("target_ports", [])
+                )
+                hash_input = (
+                    f"{campaign_id}|"
+                    f"{'|'.join(source_ips)}|"
+                    f"{'|'.join(target_ports)}"
+                )
+                campaign_hash = hashlib.sha256(
+                    hash_input.encode("utf-8")
+                ).hexdigest()[:16]
+
+                # Dedup check
+                if campaign_hash in self._sentinel_processed_hashes:
+                    logger.debug(
+                        "[Sentinel AutoGen] SKIP campaign %s (hash=%s, already processed)",
+                        campaign_id,
+                        campaign_hash,
+                    )
+                    skipped_count += 1
+                    continue
+
+                # Map campaign fields → SentinelService format
+                campaign_data = {
+                    "source_ips": campaign.get("unique_sources", []),
+                    "target_ports": campaign.get("target_ports", []),
+                    "protocols": campaign.get("protocols", ["TCP"]),
+                    "event_count": campaign.get("event_count", 0),
+                    "campaign_id": campaign_id,
+                    "time_range": {
+                        "start": campaign.get("start_time"),
+                        "end": campaign.get("end_time"),
+                    }
+                    if campaign.get("start_time")
+                    else None,
+                }
+
+                try:
+                    svc.generate_playbook(campaign_data)
+                    self._sentinel_processed_hashes.add(campaign_hash)
+                    new_count += 1
+                    logger.info(
+                        "[Sentinel AutoGen] GENERATED playbook for campaign %s "
+                        "(hash=%s, ips=%d, ports=%s, events=%d)",
+                        campaign_id,
+                        campaign_hash,
+                        len(campaign_data["source_ips"]),
+                        campaign_data["target_ports"],
+                        campaign_data["event_count"],
+                    )
+                except Exception as gen_exc:
+                    error_count += 1
+                    logger.error(
+                        "[Sentinel AutoGen] FAILED to generate playbook for "
+                        "campaign %s: %s",
+                        campaign_id,
+                        gen_exc,
+                    )
+        finally:
+            db.close()
+
+        # Cycle summary
+        logger.info(
+            "[Sentinel AutoGen] SUMMARY: found=%d, new=%d, skipped=%d, "
+            "errors=%d, total_tracked=%d",
+            total_found,
+            new_count,
+            skipped_count,
+            error_count,
+            len(self._sentinel_processed_hashes),
+        )
+        logger.info("=" * 60)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers (for API / health checks)
+    # ------------------------------------------------------------------
+    def get_sentinel_auto_gen_status(self) -> dict:
+        """Return the current status of the sentinel auto-gen job.
+
+        Returns
+        -------
+        dict
+            Keys: enabled, job_registered, interval_minutes, is_locked,
+            tracked_hashes_count, next_run_time.
+        """
+        from config.sentinel_config import (
+            SENTINEL_AUTO_GEN_ENABLED,
+            SENTINEL_AUTO_GEN_INTERVAL_MINUTES,
+        )
+
+        job = self.scheduler.get_job("sentinel_auto_gen")
+
+        return {
+            "enabled": SENTINEL_AUTO_GEN_ENABLED,
+            "job_registered": job is not None,
+            "interval_minutes": SENTINEL_AUTO_GEN_INTERVAL_MINUTES,
+            "is_locked": self._sentinel_lock.locked(),
+            "tracked_hashes_count": len(self._sentinel_processed_hashes),
+            "next_run_time": (
+                job.next_run_time.isoformat() if job and job.next_run_time else None
+            ),
+        }
 
 
 scheduler_service = SchedulerService()

--- a/tests/test_sentinel_scheduler.py
+++ b/tests/test_sentinel_scheduler.py
@@ -1,0 +1,333 @@
+"""
+tests/test_sentinel_scheduler.py
+---------------------------------
+Unit tests for the Sentinel Auto-Generation Scheduler.
+
+Validates:
+  1. Configuration module reads environment variables correctly.
+  2. SchedulerService.start_sentinel_auto_gen() registers / skips the job
+     based on SENTINEL_AUTO_GEN_ENABLED.
+  3. Locking mechanism prevents concurrent sentinel generation cycles.
+  4. Dedup hash logic skips already-processed campaigns.
+  5. Status introspection returns correct metadata.
+
+Phase 5, Week 4 — Sentinel Auto-Generation Scheduler Tests
+"""
+
+import os
+import sys
+import hashlib
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Force SQLite test database and test environment before importing application modules
+os.environ["DATABASE_URL"] = "sqlite:///./phantomnet.db"
+os.environ["ENVIRONMENT"] = "test"
+
+# Ensure backend and root project directories are in sys.path
+dir_path = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.abspath(os.path.join(dir_path, ".."))
+backend_dir = os.path.join(root_dir, "backend")
+
+if backend_dir not in sys.path:
+    sys.path.insert(0, backend_dir)
+if root_dir not in sys.path:
+    sys.path.insert(0, root_dir)
+
+
+class TestSentinelConfig(unittest.TestCase):
+    """Tests for backend/config/sentinel_config.py."""
+
+    def test_env_bool_true_values(self):
+        """_env_bool returns True for 'true', '1', 'yes', 'on'."""
+        from config.sentinel_config import _env_bool
+
+        for val in ("true", "1", "yes", "on", "TRUE", "True", "YES", "ON"):
+            with patch.dict(os.environ, {"TEST_BOOL": val}):
+                self.assertTrue(_env_bool("TEST_BOOL", default=False))
+
+    def test_env_bool_false_values(self):
+        """_env_bool returns False for 'false', '0', 'no', random strings."""
+        from config.sentinel_config import _env_bool
+
+        for val in ("false", "0", "no", "off", "random"):
+            with patch.dict(os.environ, {"TEST_BOOL": val}):
+                self.assertFalse(_env_bool("TEST_BOOL", default=False))
+
+    def test_env_bool_missing_uses_default(self):
+        """_env_bool returns default when env var is not set."""
+        from config.sentinel_config import _env_bool
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NONEXISTENT_VAR", None)
+            self.assertTrue(_env_bool("NONEXISTENT_VAR", default=True))
+            self.assertFalse(_env_bool("NONEXISTENT_VAR", default=False))
+
+    def test_env_int_valid(self):
+        """_env_int parses valid integers correctly."""
+        from config.sentinel_config import _env_int
+
+        with patch.dict(os.environ, {"TEST_INT": "42"}):
+            self.assertEqual(_env_int("TEST_INT", default=0), 42)
+
+    def test_env_int_invalid_uses_default(self):
+        """_env_int returns default for non-integer strings."""
+        from config.sentinel_config import _env_int
+
+        with patch.dict(os.environ, {"TEST_INT": "not_a_number"}):
+            self.assertEqual(_env_int("TEST_INT", default=99), 99)
+
+    def test_env_int_missing_uses_default(self):
+        """_env_int returns default when env var is not set."""
+        from config.sentinel_config import _env_int
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NONEXISTENT_INT", None)
+            self.assertEqual(_env_int("NONEXISTENT_INT", default=15), 15)
+
+
+class TestSchedulerServiceSentinel(unittest.TestCase):
+    """Tests for SchedulerService sentinel auto-gen integration."""
+
+    def _make_service(self):
+        """Create a fresh SchedulerService with a non-started scheduler."""
+        from services.scheduler_service import SchedulerService
+
+        svc = SchedulerService()
+        return svc
+
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_ENABLED", False)
+    def test_start_auto_gen_disabled(self):
+        """start_sentinel_auto_gen returns False when disabled."""
+        svc = self._make_service()
+        result = svc.start_sentinel_auto_gen()
+        self.assertFalse(result)
+
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_ENABLED", True)
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_INTERVAL_MINUTES", 5)
+    def test_start_auto_gen_enabled_registers_job(self):
+        """start_sentinel_auto_gen registers the APScheduler job when enabled."""
+        svc = self._make_service()
+        # Manually start the scheduler for test
+        if not svc.scheduler.running:
+            svc.scheduler.start()
+
+        result = svc.start_sentinel_auto_gen()
+        self.assertTrue(result)
+
+        # Verify job exists
+        job = svc.scheduler.get_job("sentinel_auto_gen")
+        self.assertIsNotNone(job)
+        self.assertEqual(job.name, "Sentinel Playbook Auto-Generation")
+
+        svc.scheduler.shutdown(wait=False)
+
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_ENABLED", True)
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_INTERVAL_MINUTES", 5)
+    def test_start_auto_gen_idempotent(self):
+        """Calling start_sentinel_auto_gen twice does not create duplicate jobs."""
+        svc = self._make_service()
+        if not svc.scheduler.running:
+            svc.scheduler.start()
+
+        svc.start_sentinel_auto_gen()
+        svc.start_sentinel_auto_gen()
+
+        jobs = svc.scheduler.get_jobs()
+        sentinel_jobs = [j for j in jobs if j.id == "sentinel_auto_gen"]
+        self.assertEqual(len(sentinel_jobs), 1)
+
+        svc.scheduler.shutdown(wait=False)
+
+    def test_stop_auto_gen_no_job(self):
+        """stop_sentinel_auto_gen returns False when no job is registered."""
+        svc = self._make_service()
+        result = svc.stop_sentinel_auto_gen()
+        self.assertFalse(result)
+
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_ENABLED", True)
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_INTERVAL_MINUTES", 5)
+    def test_stop_auto_gen_removes_job(self):
+        """stop_sentinel_auto_gen removes an existing job."""
+        svc = self._make_service()
+        if not svc.scheduler.running:
+            svc.scheduler.start()
+
+        svc.start_sentinel_auto_gen()
+        result = svc.stop_sentinel_auto_gen()
+        self.assertTrue(result)
+
+        job = svc.scheduler.get_job("sentinel_auto_gen")
+        self.assertIsNone(job)
+
+        svc.scheduler.shutdown(wait=False)
+
+    def test_lock_prevents_concurrent_execution(self):
+        """Concurrent cycles are blocked by the threading.Lock."""
+        svc = self._make_service()
+
+        # Simulate a long-running cycle holding the lock
+        svc._sentinel_lock.acquire()
+
+        # Attempting to run another cycle should skip (non-blocking)
+        with patch.object(svc, "_execute_sentinel_cycle") as mock_exec:
+            svc._run_sentinel_auto_gen_cycle()
+            mock_exec.assert_not_called()
+
+        svc._sentinel_lock.release()
+
+    def test_lock_allows_execution_when_free(self):
+        """Cycle executes normally when lock is free."""
+        svc = self._make_service()
+
+        with patch.object(svc, "_execute_sentinel_cycle") as mock_exec:
+            svc._run_sentinel_auto_gen_cycle()
+            mock_exec.assert_called_once()
+
+    def test_dedup_hash_generation(self):
+        """Deterministic campaign hash is consistent."""
+        campaign_id = "CAMP-001"
+        source_ips = sorted(["10.0.0.1", "10.0.0.2"])
+        target_ports = sorted(["22", "8080"])
+        hash_input = (
+            f"{campaign_id}|"
+            f"{'|'.join(source_ips)}|"
+            f"{'|'.join(target_ports)}"
+        )
+        expected = hashlib.sha256(hash_input.encode("utf-8")).hexdigest()[:16]
+
+        # Re-compute to confirm determinism
+        hash_input_2 = (
+            f"{campaign_id}|"
+            f"{'|'.join(source_ips)}|"
+            f"{'|'.join(target_ports)}"
+        )
+        actual = hashlib.sha256(hash_input_2.encode("utf-8")).hexdigest()[:16]
+        self.assertEqual(expected, actual)
+
+    def test_dedup_skips_known_campaigns(self):
+        """Already-processed campaign hashes are skipped."""
+        svc = self._make_service()
+        svc._sentinel_seeded = True  # Skip DB pre-seeding
+
+        # Pre-populate a known hash
+        known_hash = "abcdef1234567890"
+        svc._sentinel_processed_hashes.add(known_hash)
+
+        # The cycle should skip this campaign
+        self.assertIn(known_hash, svc._sentinel_processed_hashes)
+
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_ENABLED", True)
+    @patch("config.sentinel_config.SENTINEL_AUTO_GEN_INTERVAL_MINUTES", 10)
+    def test_get_status_returns_metadata(self):
+        """get_sentinel_auto_gen_status returns correct structure."""
+        svc = self._make_service()
+        if not svc.scheduler.running:
+            svc.scheduler.start()
+
+        svc.start_sentinel_auto_gen()
+
+        status = svc.get_sentinel_auto_gen_status()
+
+        self.assertIn("enabled", status)
+        self.assertIn("job_registered", status)
+        self.assertIn("interval_minutes", status)
+        self.assertIn("is_locked", status)
+        self.assertIn("tracked_hashes_count", status)
+        self.assertIn("next_run_time", status)
+
+        self.assertTrue(status["job_registered"])
+        self.assertEqual(status["interval_minutes"], 10)
+        self.assertFalse(status["is_locked"])
+        self.assertIsNotNone(status["next_run_time"])
+
+        svc.scheduler.shutdown(wait=False)
+
+    def test_execute_cycle_no_campaigns(self):
+        """Cycle exits early when no campaigns are found."""
+        svc = self._make_service()
+        svc._sentinel_seeded = True  # Skip DB seeding
+
+        with patch(
+            "services.scheduler_service.campaign_clusterer",
+            create=True,
+        ) as mock_clusterer:
+            # Patch the import inside the method
+            mock_clusterer.identify_campaigns.return_value = {
+                "campaign_count": 0,
+                "campaigns": [],
+            }
+
+            # Patch the dynamic import within _execute_sentinel_cycle
+            with patch.dict("sys.modules", {
+                "ml_engine.campaign_clustering": MagicMock(
+                    campaign_clusterer=mock_clusterer
+                ),
+            }):
+                svc._execute_sentinel_cycle()
+                mock_clusterer.identify_campaigns.assert_called_once_with(24)
+
+    def test_execute_cycle_processes_new_campaign(self):
+        """Cycle processes a new campaign and adds hash to dedup set."""
+        svc = self._make_service()
+        svc._sentinel_seeded = True
+
+        mock_clusterer = MagicMock()
+        mock_clusterer.identify_campaigns.return_value = {
+            "campaign_count": 1,
+            "campaigns": [
+                {
+                    "campaign_id": "CAMP-TEST-001",
+                    "unique_sources": ["192.168.1.1"],
+                    "target_ports": [2222],
+                    "protocols": ["TCP"],
+                    "event_count": 50,
+                    "start_time": None,
+                    "end_time": None,
+                },
+            ],
+        }
+
+        mock_svc_instance = MagicMock()
+        mock_svc_cls = MagicMock(return_value=mock_svc_instance)
+
+        mock_session = MagicMock()
+
+        with patch.dict("sys.modules", {
+            "ml_engine.campaign_clustering": MagicMock(
+                campaign_clusterer=mock_clusterer
+            ),
+            "sentinel.sentinel_service": MagicMock(
+                SentinelService=mock_svc_cls
+            ),
+        }):
+            with patch(
+                "services.scheduler_service.SessionLocal",
+                return_value=mock_session,
+            ):
+                svc._execute_sentinel_cycle()
+
+                # Verify generate_playbook was called
+                mock_svc_instance.generate_playbook.assert_called_once()
+
+                # Verify the hash was added to dedup set
+                self.assertGreater(len(svc._sentinel_processed_hashes), 0)
+
+    def test_lock_is_released_on_exception(self):
+        """Lock is released even if _execute_sentinel_cycle raises."""
+        svc = self._make_service()
+
+        with patch.object(
+            svc, "_execute_sentinel_cycle", side_effect=RuntimeError("boom")
+        ):
+            # Should not raise — lock should be released
+            svc._run_sentinel_auto_gen_cycle()
+
+        # Lock should be free
+        self.assertFalse(svc._sentinel_lock.locked())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements an automated background task scheduler that periodically triggers sentinel playbook generation via APScheduler interval jobs.

## Changes

### New Files
- **backend/config/sentinel_config.py** - Centralised configuration module reading SENTINEL_AUTO_GEN_ENABLED and SENTINEL_AUTO_GEN_INTERVAL_MINUTES from environment variables with safe defaults and clamping
- **tests/test_sentinel_scheduler.py** - 19 unit tests covering config parsing, job registration, locking, dedup, status introspection, and cycle execution

### Modified Files
- **backend/services/scheduler_service.py** - Extended SchedulerService with APScheduler interval job, threading.Lock concurrency guard, DB pre-seeded dedup, and status introspection
- **backend/main.py** - Integrated scheduler startup/shutdown into FastAPI lifespan
- **.env.example** - Added documentation for new configuration flags

## Configuration
`env
SENTINEL_AUTO_GEN_ENABLED=true
SENTINEL_AUTO_GEN_INTERVAL_MINUTES=30
``n
## Concurrency Safety
Uses threading.Lock with non-blocking acquire(blocking=False) - if a previous cycle is still running, the new invocation is skipped rather than queued.

## Test Results
19/19 tests passing