### PR TITLE
Implement LLM Request Queuing and Stress Test

### DIFF
--- a/backend/sentinel/llm_service.py
+++ b/backend/sentinel/llm_service.py
@@ -357,6 +357,7 @@ class LLMService:
             # Use asyncio.timeout (or wait_for if on older python, but 3.11+ supports timeout)
             # Actually, using wait_for is safer across python versions if timeout doesn't exist
             async def _do_request():
+                global last_generation_time_ms
                 async with httpx.AsyncClient(timeout=_OLLAMA_TIMEOUT) as client:
                     if stream:
                         # ---- Streaming path: aggregate NDJSON chunks ----
@@ -389,7 +390,6 @@ class LLMService:
     
                         raw_text = "".join(collected_tokens)
                         latency_ms = (time.time() - start_time) * 1000
-                        global last_generation_time_ms
                         last_generation_time_ms = latency_ms
     
                         if latency_ms > 25000:
@@ -414,7 +414,6 @@ class LLMService:
                         result = response.json()
                         raw_text = result.get("response", "")
                         latency_ms = (time.time() - start_time) * 1000
-                        global last_generation_time_ms
                         last_generation_time_ms = latency_ms
     
                         if latency_ms > 25000:
@@ -428,19 +427,17 @@ class LLMService:
                     clean_text = self._clean_markdown(raw_text)
                     return clean_text
 
-            async def _do_request_with_semaphore():
-                async with sem:
-                    return await _do_request()
-
-            # Wait for semaphore and execute request with an overall 65 second timeout
-            return await asyncio.wait_for(
-                _do_request_with_semaphore(),
-                timeout=65.0
-            )
+            # Wait for semaphore without a timeout to support long queues
+            async with sem:
+                # Execute request with an overall 65 second timeout
+                return await asyncio.wait_for(
+                    _do_request(),
+                    timeout=65.0
+                )
 
         except asyncio.TimeoutError:
             logger.warning(
-                "LLMService._call_ollama: timeout waiting for semaphore or executing."
+                "LLMService._call_ollama: request execution timed out after 65 seconds."
             )
             return ""
         except httpx.TimeoutException as exc:
@@ -923,16 +920,23 @@ async def generate_playbook_summary(
         if llm_enabled:
             try:
                 start_time = time.time()
-                # Week 17 Day 3: strict 60-second connect + read timeout
-                async with httpx.AsyncClient(timeout=_OLLAMA_TIMEOUT) as client:
-                    response = await client.post(
-                        f"{SENTINEL_LLM_HOST}/api/generate",
-                        json={
-                            "model": SENTINEL_LLM_MODEL,
-                            "prompt": prompt,
-                            "stream": False,
-                        },
-                    )
+                sem = get_llm_semaphore()
+                # Wait for semaphore to queue requests
+                async with sem:
+                    # Execute request inside semaphore
+                    async def _do_generate():
+                        async with httpx.AsyncClient(timeout=_OLLAMA_TIMEOUT) as client:
+                            return await client.post(
+                                f"{SENTINEL_LLM_HOST}/api/generate",
+                                json={
+                                    "model": SENTINEL_LLM_MODEL,
+                                    "prompt": prompt,
+                                    "stream": False,
+                                },
+                            )
+                    
+                    response = await asyncio.wait_for(_do_generate(), timeout=65.0)
+                    
                     if response.status_code == 200:
                         latency_ms = (time.time() - start_time) * 1000
                         last_generation_time_ms = latency_ms
@@ -954,6 +958,10 @@ async def generate_playbook_summary(
                             "Ollama API returned status %d. Using local fallback.",
                             response.status_code,
                         )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Ollama request execution timed out after 65 seconds. Using local fallback."
+                )
             except httpx.TimeoutException as exc:
                 logger.warning(
                     "Ollama timeout (60 s) at %s: %s. Using local fallback.",

--- a/tests/integration/test_llm_stress.py
+++ b/tests/integration/test_llm_stress.py
@@ -1,0 +1,70 @@
+import asyncio
+import time
+import logging
+import psutil
+import os
+import sys
+
+# Set environment variables before imports to mock DB connection
+os.environ["ENVIRONMENT"] = "test"
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["SENTINEL_LLM_ENABLED"] = "true"
+os.environ["SENTINEL_LLM_HOST"] = "http://localhost:11434"
+
+# Add the backend to sys path so we can import modules
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../backend')))
+
+from sentinel.llm_service import LLMService
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("llm_stress_test")
+
+async def trigger_llm(svc, context, i):
+    logger.info(f"Triggering request {i}...")
+    start_time = time.time()
+    narrative = await svc.async_generate_narrative(context)
+    duration = time.time() - start_time
+    logger.info(f"Request {i} finished in {duration:.2f}s. Length: {len(narrative)}")
+    return duration
+
+async def main():
+    # Using local mock server or Ollama instance if available
+    svc = LLMService()
+    svc.enabled = True
+    
+    context = {
+        "attack_type": "Stress Test",
+        "severity": "CRITICAL",
+        "src_ip": "1.2.3.4",
+        "dst_port": 80,
+        "protocol": "TCP",
+    }
+    
+    num_requests = 10
+    
+    cpu_start = psutil.cpu_percent(interval=1)
+    mem_start = psutil.virtual_memory().percent
+    logger.info(f"Initial CPU: {cpu_start}%, Mem: {mem_start}%")
+    
+    overall_start = time.time()
+    
+    tasks = [trigger_llm(svc, context, i) for i in range(num_requests)]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    
+    overall_time = time.time() - overall_start
+    cpu_end = psutil.cpu_percent(interval=1)
+    mem_end = psutil.virtual_memory().percent
+    
+    logger.info(f"Final CPU: {cpu_end}%, Mem: {mem_end}%")
+    logger.info(f"Total time for {num_requests} requests: {overall_time:.2f}s")
+    
+    successes = [r for r in results if isinstance(r, float)]
+    errors = [r for r in results if isinstance(r, Exception)]
+    
+    if successes:
+        avg_time = sum(successes) / len(successes)
+        logger.info(f"Average time per successful request: {avg_time:.2f}s")
+    logger.info(f"Successful: {len(successes)}, Errors: {len(errors)}")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Objective
Implemented request queuing to prevent LLM service crash under heavy load and added a stress test script to evaluate performance.

## Changes
*   **Request Queuing:** Separated semaphore wait from request execution timeouts in \llm_service.py\ to support long queues.
*   **Consolidated Generations:** Modified \generate_playbook_summary\ to use the semaphore wrapper instead of a raw httpx call.
*   **Stress Test:** Created \	ests/integration/test_llm_stress.py\ to spawn concurrent async requests, queue them, and monitor system CPU/Mem alongside request duration.